### PR TITLE
Setup CI build

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -36,6 +36,7 @@ project {
         id = RelativeId(name.toId())
         vcs {
             root(DslContext.settingsRootId)
+            // prevent stale files from a failed release build
             cleanCheckout = true
         }
         triggers {


### PR DESCRIPTION
This add a verify build to the TeamCity pipeline that is triggered on
each commit on the default branch. The verify build simply calls

  mvn verify

Instead of deactivating bulid scans using -Dscan=false we now specify
e.grdev.net as the scan server making it possible to review build scans
produced from the TeamCity pipeline.