### PR TITLE
Configure project for log parsing

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -31,6 +31,9 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2019.2"
 
 project {
+    params {
+        param("BUILD_SCAN_LOG_PARSING", "true")
+    }
     buildType {
         name = "Verify"
         id = RelativeId(name.toId())


### PR DESCRIPTION
Sets an environment variable that is picked up by the build scans
TeamCity plugin to parse the build scan link from the logs.