### PR TITLE
Change snapshot version to 1.0.1-SNAPSHOT

### DIFF
--- a/common-custom-user-data-maven-extension/pom.xml
+++ b/common-custom-user-data-maven-extension/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.gradle</groupId>
     <artifactId>common-custom-user-data-maven-extension</artifactId>
     <packaging>jar</packaging>
-    <version>1.1-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>Gradle Enterprise Common Custom User Data Maven Extension</name>
     <description>A Maven extension to capture common custom user data used for Maven Build Scans in Gradle Enterprise</description>
     <url>https://github.com/gradle/gradle-build-scan-snippets/tree/master/common-custom-user-data-maven-extension</url>


### PR DESCRIPTION
Since we are about to release a patch version 1.0.1, the current snapshot version should be 1.0.1-SNAPSHOT.