### PR TITLE
Remove env variable since no longer required

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -33,9 +33,6 @@ To debug in IntelliJ Idea, open the 'Maven Projects' tool window (View
 version = "2019.2"
 
 project {
-    params {
-        param("BUILD_SCAN_LOG_PARSING", "true")
-    }
     buildType {
         name = "Verify"
         id = RelativeId(name.toId())


### PR DESCRIPTION
Parsing the log is no longer needed for retrieving the build scan id since the upgrade of the TeamCity build scan plugin to v0.15.

Therefore we can remove the environment variable `BUILD_SCAN_LOG_PARSING`.

(https://gradle.slack.com/archives/C013WF0TWTU/p1591956537034100?thread_ts=1591901985.032600&cid=C013WF0TWTU)
