### PR TITLE
Use TC temp dir for storage of GE Maven extension

### DIFF
--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -120,7 +120,7 @@ fun BuildSteps.maven(goal: String, args: String?) {
     this.maven {
         pomLocation = "common-custom-user-data-maven-extension/pom.xml"
         goals = goal
-        runnerArgs = "-Dgradle.enterprise.url=https://e.grdev.net" + (args?.let { " $it" } ?: "")
+        runnerArgs = "-Dgradle.enterprise.url=https://e.grdev.net -Dgradle.enterprise.storage.directory=%teamcity.build.tempDir%/.gradle-enterprise" + (args?.let { " $it" } ?: "")
         mavenVersion = custom {
             path = "%teamcity.tool.maven.3.6.3%"
         }


### PR DESCRIPTION
To avoid polluting `~/.m2`, the temp dir provided by TeamCity is now used
for temporary storage by the Gradle Enterprise Maven extension used in
the build.