### PR TITLE
Optionally evaluate Groovy script if exists

### DIFF
--- a/common-custom-user-data-maven-extension/pom.xml
+++ b/common-custom-user-data-maven-extension/pom.xml
@@ -68,6 +68,11 @@
             <version>1.5.1</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy</artifactId>
+            <version>3.0.4</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CommonCustomUserDataMavenExtension.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CommonCustomUserDataMavenExtension.java
@@ -29,6 +29,7 @@ public final class CommonCustomUserDataMavenExtension extends AbstractMavenLifec
         if (buildScan != null) {
             logger.debug("Capturing custom user data in build scan");
             CustomUserData.addToBuildScan(buildScan);
+            GroovyScriptUserData.addToBuildScan(session, buildScan, logger);
             logger.debug("Finished capturing custom user data in build scans");
         }
     }

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/GroovyScriptUserData.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/GroovyScriptUserData.java
@@ -1,0 +1,48 @@
+package com.gradle;
+
+import com.gradle.maven.extension.api.scan.BuildScanApi;
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+import org.apache.maven.MavenExecutionException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.codehaus.plexus.logging.Logger;
+
+import java.io.File;
+import java.io.IOException;
+
+class GroovyScriptUserData {
+
+    static void addToBuildScan(MavenSession session, BuildScanApi buildScan, Logger logger) throws MavenExecutionException {
+        File scriptFile = getScriptFile(session);
+        if (scriptFile.exists()) {
+            logger.debug("Evaluating custom user data Groovy script: " + scriptFile);
+            evaluateGroovyScript(session, buildScan, logger, scriptFile);
+        } else {
+            logger.debug("Skipping evaluation of custom user data Groovy script because it does not exist: " + scriptFile);
+        }
+    }
+
+    private static File getScriptFile(MavenSession session) {
+        File rootDir = session.getRequest().getMultiModuleProjectDirectory();
+        return new File(rootDir, ".mvn/gradle-enterprise-custom-user-data.groovy");
+    }
+
+    private static void evaluateGroovyScript(MavenSession session, BuildScanApi buildScan, Logger logger, File scriptFile) throws MavenExecutionException {
+        try {
+            Binding binding = prepareBinding(session, buildScan, logger);
+            new GroovyShell(GroovyScriptUserData.class.getClassLoader(), binding).evaluate(scriptFile);
+        } catch (IOException e) {
+            throw new MavenExecutionException("Failed to evaluate custom user data Groovy script: " + scriptFile, e);
+        }
+    }
+
+    private static Binding prepareBinding(MavenSession session, BuildScanApi buildScan, Logger logger) {
+        Binding binding = new Binding();
+        binding.setVariable("project", session.getTopLevelProject());
+        binding.setVariable("session", session);
+        binding.setVariable("buildScan", buildScan);
+        binding.setVariable("log", new DefaultLog(logger));
+        return binding;
+    }
+}


### PR DESCRIPTION
In addition to the custom user data added via Java code in
`CustomUserData`, the extension now checks for a Groovy script in
`.mvn/gradle-enterprise-custom-user-data.groovy` and evaluates it if it
exists.