### PR TITLE
Add script to capture execution root name/artifactId

### DIFF
--- a/capture-reactor-projects/maven-reactor-projects.groovy
+++ b/capture-reactor-projects/maven-reactor-projects.groovy
@@ -1,9 +1,0 @@
-/**
- * This Groovy script adds a custom value for each Maven project in the reactor.
- */
-
-BuildScanApi buildScan = session.lookup('com.gradle.maven.extension.api.scan.BuildScanApi')
-if (!buildScan) {
-    return
-}
-buildScan.value('Project', project.name)

--- a/capture-top-level-project/gradle-enterprise-custom-user-data.groovy
+++ b/capture-top-level-project/gradle-enterprise-custom-user-data.groovy
@@ -2,5 +2,5 @@
 // It needs to be placed in .mvn/gradle-enterprise-custom-user-data.groovy in the root project directory.
 // (see https://docs.gradle.com/enterprise/maven-extension/#using_the_common_custom_user_data_maven_extension)
 
-buildScan.value('topLevelProject.name', session.topLevelProject.name)
-buildScan.value('topLevelProject.artifactId', session.topLevelProject.artifactId)
+buildScan.value('executionRoot.name', session.topLevelProject.name)
+buildScan.value('executionRoot.artifactId', session.topLevelProject.artifactId)

--- a/capture-top-level-project/gradle-enterprise-custom-user-data.groovy
+++ b/capture-top-level-project/gradle-enterprise-custom-user-data.groovy
@@ -1,0 +1,6 @@
+// This script is meant to be used with the common-custom-user-data-maven-extension.
+// It needs to be placed in .mvn/gradle-enterprise-custom-user-data.groovy in the root project directory.
+// (see https://docs.gradle.com/enterprise/maven-extension/#using_the_common_custom_user_data_maven_extension)
+
+buildScan.value('topLevelProject.name', session.topLevelProject.name)
+buildScan.value('topLevelProject.artifactId', session.topLevelProject.artifactId)


### PR DESCRIPTION
This allows to filter the list of build scans by the project Maven was
invoked on, e.g. using `mvn -f`.