### PR TITLE
Add support for tagging old Idea releases

### DIFF
--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomUserData.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomUserData.java
@@ -38,7 +38,7 @@ final class CustomUserData {
     }
 
     private static void tagIde(BuildScanApi buildScan) {
-        if (sysPropertyPresent("idea.version")) {
+        if (sysPropertyPresent("idea.version") || sysPropertyKeyStartingWith("idea.version")) {
             buildScan.tag("IntelliJ IDEA");
         } else if (sysPropertyPresent("eclipse.buildId")) {
             buildScan.tag("Eclipse");
@@ -343,6 +343,18 @@ final class CustomUserData {
 
     private static boolean sysPropertyPresent(String name) {
         return !Strings.isNullOrEmpty(sysProperty(name));
+    }
+
+    private static boolean sysPropertyKeyStartingWith(String keyPrefix) {
+        for (Object key : System.getProperties().keySet()) {
+            if (key instanceof String) {
+                String stringKey = (String) key;
+                if (stringKey.startsWith(keyPrefix)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static String envVariable(String name) {

--- a/common-custom-user-data-scripts/maven-common-custom-user-data.groovy
+++ b/common-custom-user-data-scripts/maven-common-custom-user-data.groovy
@@ -37,7 +37,7 @@ static void tagOs(def buildScan) {
 }
 
 static void tagIde(def buildScan) {
-    if (System.getProperty('idea.version')) {
+    if (System.getProperty('idea.version') || sysPropertyKeyStartingWith("idea.version")) {
         buildScan.tag 'IntelliJ IDEA'
     } else if (System.getProperty('eclipse.buildId')) {
         buildScan.tag 'Eclipse'
@@ -314,6 +314,18 @@ static String customValueSearchParams(Map<String, String> search) {
     search.collect { name, value ->
         "search.names=${urlEncode(name)}&search.values=${urlEncode(value)}"
     }.join('&')
+}
+
+static boolean sysPropertyKeyStartingWith(String keyPrefix) {
+    for (Object key : System.getProperties().keySet()) {
+        if (key instanceof String) {
+            String stringKey = (String) key
+            if (stringKey.startsWith(keyPrefix)) {
+                return true
+            }
+        }
+    }
+    return false
 }
 
 static String appendIfMissing(String str, String suffix) {


### PR DESCRIPTION
Releases prior to IntelliJ 2020.2 used to add a system property of the
form `-Didea.version2019.4` to the command line. So instead of having a
property with key `idea.version` and the version as value there was a
key that carried the version information.