### PR TITLE
Make Common Custom User Data Script compatible with the configuration cache.

### DIFF
--- a/common-custom-user-data-gradle-script/common-custom-user-data.gradle
+++ b/common-custom-user-data-gradle-script/common-custom-user-data.gradle
@@ -259,35 +259,35 @@ void addTestSystemProperties() {
     }
 }
 
-boolean isCi() {
+static boolean isCi() {
     isJenkins() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis()
 }
 
-boolean isJenkins() {
+static boolean isJenkins() {
     System.getenv('JENKINS_URL')
 }
 
-boolean isTeamCity() {
+static boolean isTeamCity() {
     System.getenv('TEAMCITY_VERSION')
 }
 
-boolean isCircleCI() {
+static boolean isCircleCI() {
     System.getenv('CIRCLE_BUILD_URL')
 }
 
-boolean isBamboo() {
+static boolean isBamboo() {
     System.getenv('bamboo_resultsUrl')
 }
 
-boolean isGitHubActions() {
+static boolean isGitHubActions() {
     System.getenv('GITHUB_ACTIONS')
 }
 
-boolean isGitLab() {
+static boolean isGitLab() {
     System.getenv('GITLAB_CI')
 }
 
-boolean isTravis() {
+static boolean isTravis() {
     System.getenv('TRAVIS_JOB_ID')
 }
 
@@ -331,13 +331,13 @@ static void addCustomLinkWithSearchTerms(def buildScan, String title, Map<String
     }
 }
 
-String customValueSearchParams(Map<String, String> search) {
+static String customValueSearchParams(Map<String, String> search) {
     search.collect { name, value ->
         "search.names=${urlEncode(name)}&search.values=${urlEncode(value)}"
     }.join('&')
 }
 
-String appendIfMissing(String str, String suffix) {
+static String appendIfMissing(String str, String suffix) {
     str.endsWith(suffix) ? str : str + suffix
 }
 
@@ -345,11 +345,11 @@ static String trimAtEnd(String str) {
     ('x' + str).trim().substring(1)
 }
 
-String urlEncode(String url) {
+static String urlEncode(String url) {
     URLEncoder.encode(url, 'UTF-8')
 }
 
-Properties readPropertiesFile(String name) {
+static Properties readPropertiesFile(String name) {
     Properties properties = new Properties()
     File file = new File(name)
     file.withInputStream {

--- a/common-custom-user-data-gradle-script/common-custom-user-data.gradle
+++ b/common-custom-user-data-gradle-script/common-custom-user-data.gradle
@@ -219,7 +219,7 @@ void addGitMetadata() {
         if (gitCommitId) {
             def gitCommitIdLabel = 'Git commit id'
             api.value gitCommitIdLabel, gitCommitId
-            addCustomLinkWithSearchTerms buildScan, 'Git commit id build scans', [(gitCommitIdLabel): gitCommitId]
+            addCustomLinkWithSearchTerms api, 'Git commit id build scans', [(gitCommitIdLabel): gitCommitId]
 
             def originUrl = execAndGetStdout('git', 'config', '--get', 'remote.origin.url')
             if (originUrl) {
@@ -291,7 +291,7 @@ boolean isTravis() {
     System.getenv('TRAVIS_JOB_ID')
 }
 
-boolean isGitInstalled() {
+static boolean isGitInstalled() {
     Process process
     try {
         process = 'git --version'.execute()
@@ -306,7 +306,7 @@ boolean isGitInstalled() {
     }
 }
 
-String execAndGetStdout(String... args) {
+static String execAndGetStdout(String... args) {
     Process process = args.toList().execute()
     try {
         def standardText = process.getInputStream().getText(Charset.defaultCharset().name())
@@ -319,7 +319,7 @@ String execAndGetStdout(String... args) {
     }
 }
 
-void addCustomLinkWithSearchTerms(def buildScan, String title, Map<String, String> search) {
+static void addCustomLinkWithSearchTerms(def buildScan, String title, Map<String, String> search) {
     // This fails with Build Scan plugin v1.16.
     // As a workaround, you can specify the BuildScan server URL directly: e.g. `def server = "http://localhost"`
     def server = buildScan.server
@@ -341,7 +341,7 @@ String appendIfMissing(String str, String suffix) {
     str.endsWith(suffix) ? str : str + suffix
 }
 
-String trimAtEnd(String str) {
+static String trimAtEnd(String str) {
     ('x' + str).trim().substring(1)
 }
 


### PR DESCRIPTION
This makes the Gradle common custom user data script compatible with the configuration cache.
I tested this in a very simple Gradle project with git installed using Gradle 6.6 and 6.7-rc-1.
I verified that the Git status custom value was correctly plublished in the build scans.

Here's a build scan I published with the configuration cache enabled using these changes: https://scans.gradle.com/s/gimsuc3veohve/custom-values#L0
