### PR TITLE
Use sign-maven-plugin for signing

### DIFF
--- a/common-custom-user-data-maven-extension/pom.xml
+++ b/common-custom-user-data-maven-extension/pom.xml
@@ -138,6 +138,9 @@
                                 </goals>
                             </execution>
                         </executions>
+                        <configuration>
+                            <source>8</source>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <artifactId>maven-site-plugin</artifactId>
@@ -147,20 +150,19 @@
                         </configuration>
                     </plugin>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
+                        <groupId>org.simplify4u.plugins</groupId>
+                        <artifactId>sign-maven-plugin</artifactId>
+                        <version>0.2.1</version>
                         <executions>
                             <execution>
-                                <id>sign-artifacts</id>
-                                <phase>verify</phase>
+                                <id>sign</id>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
                             </execution>
                         </executions>
                         <configuration>
-                            <keyname>5208812E1E4A6DB0</keyname>
+                            <skipNoKey>false</skipNoKey>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This plugin provides ways to inject the signing key via environment
variables and thus simplifies our CI configuration for publishing
releases.