### PR TITLE
Update documentation for custom-user-data Gradle Plugin and Maven Extension

### DIFF
--- a/common-custom-user-data-gradle-plugin/README.md
+++ b/common-custom-user-data-gradle-plugin/README.md
@@ -2,19 +2,18 @@
 
 ### Overview
 
-The Common Custom User Data Gradle Plugin for Gradle Enterprise enhances published Build Scans 
-by adding a set of Tags, Links and Custom Values that have proven to be useful for many users of Gradle Enterprise.
+The Common Custom User Data Gradle Plugin for Gradle Enterprise enhances published build scans 
+by adding a set of tags, links and custom values that have proven to be useful for many users of Gradle Enterprise.
 
 You can leverage this plugin for your project in one of two ways:
-1. Apply the published plugin directly in your build and immediately benefit from enhanced Build Scans
-2. Copy this repository and develop a customized version of the plugin which will standardize Gradle Enterprise usage across multiple projects
+1. Apply the published plugin directly in your build and immediately benefit from enhanced build scans.
+2. Copy this repository and develop a customized version of the plugin which will standardize Gradle Enterprise usage across multiple projects.
 
-Out of the box, this plugin will enhance all Build Scans published with additional tags, links and custom values. These include:
+Out of the box, this plugin enhances all build scans published with additional tags, links and custom values. These include:
 - A tag representing the Operating System.
 - A tag representing how the build was invoked, be that from your IDE (IDEA, Eclipse, Android Studio) or from the command-line.
-- A `CI` tag for builds run on CI. In addition, a set of tags, links and custom values specific to the CI server will be added.
-  - The following CI servers are supported: Jenkins, Team City, Circle CI, Bamboo, GitHub Actions, Gitlab and Travis.
-- For `git` repositories, custom values with the Commit ID, Branch and the output of `git status`
+- A tag representing builds run on CI, together with a set of tags, links and custom values specific to the CI server running the build.
+- For `git` repositories, information on the commit id, branch name, status, and whether the checkout is dirty or not.
 
 ### Applying the published plugin
 
@@ -26,13 +25,13 @@ If you are still using a 5.x version of Gradle, apply the plugin to the `build.g
 
 ### Developing a customized version of the plugin
 
-For more power and flexibility, we recommend creating a copy of this repository so that you may develop a customized version of the plugin and publish it locally for your projects to consume.
+For more flexibility, we recommend creating a copy of this repository so that you may develop a customized version of the plugin and publish it locally for your projects to consume.
 
 This approach has a number of benefits:
-- Add, remove and change the set of tags, links and custom values added to each Build Scan. This allows you to customize your Build Scans for your particular needs.
-- Standardize Gradle Enterprise and Gradle Build Cache configuration in your organization, removing the need for each project to specify this configuration.
+- Tailor the build scan enhancements to exactly the set of tags, links and custom values you require.
+- Standardize the configuration for connecting to Gradle Enterprise and Gradle Build Cache in your organization, removing the need for each project to specify this configuration.
 
-This approach can be particularly useful when Gradle Enterprise and Build Cache configuration should be shared among a number of Gradle projects. If your customized plugin provides all required Gradle Enterprise configuration, then each consumer project will get all the benefits of Gradle Enterprise simply by applying this single plugin. The plugin sources provide a placeholder and example code to get you started.
+If your customized plugin provides all required Gradle Enterprise configuration, then a consumer project will get all the benefits of Gradle Enterprise simply by applying the plugin. The plugin sources provide a placeholder and example code to get you started.
 
 See the [Gradle User Manual](https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html#custom-plugin-repositories) for more details on publishing Gradle plugins to an internal repository.
 

--- a/common-custom-user-data-gradle-plugin/README.md
+++ b/common-custom-user-data-gradle-plugin/README.md
@@ -32,7 +32,7 @@ This approach has a number of benefits:
 - Add, remove and change the set of tags, links and custom values added to each Build Scan. This allows you to customize your Build Scans for your particular needs.
 - Standardize Gradle Enterprise and Gradle Build Cache configuration in your organization, removing the need for each project to specify this configuration.
 
-This approach can be particularly useful when Gradle Enterprise and Build Cache configuration should be shared among a number of Gradle projects. If your customized plugin applies the Gradle Enterprise plugin and provides all required configuration, then each consumer project will get all the benefits of Gradle Enterprise simply by applying this single plugin.
+This approach can be particularly useful when Gradle Enterprise and Build Cache configuration should be shared among a number of Gradle projects. If your customized plugin provides all required Gradle Enterprise configuration, then each consumer project will get all the benefits of Gradle Enterprise simply by applying this single plugin. The plugin sources provide a placeholder and example code to get you started.
 
 See the [Gradle User Manual](https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html#custom-plugin-repositories) for more details on publishing Gradle plugins to an internal repository.
 

--- a/common-custom-user-data-gradle-plugin/README.md
+++ b/common-custom-user-data-gradle-plugin/README.md
@@ -2,17 +2,39 @@
 
 ### Overview
 
-The Common Custom User Data Gradle Plugin for Gradle Enterprise serves multiple purposes:
-- an example how to create a custom Gradle plugin that will standardise your Gradle Enterprise usage
-- a reusable artifact deployed to the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin) that you can apply to your Gradle builds, and it just works 
-  
-This plugin requires the the [Gradle Enterprise Gradle plugin](https://plugins.gradle.org/plugin/com.gradle.enterprise) to already be applied in your build in order to have an effect.
+The Common Custom User Data Gradle Plugin for Gradle Enterprise enhances published Build Scans 
+by adding a set of Tags, Links and Custom Values that have proven to be useful for many users of Gradle Enterprise.
 
-### Usage
+You can leverage this plugin for your project in one of two ways:
+1. Apply the published plugin directly in your build and immediately benefit from enhanced Build Scans
+2. Copy this repository and develop a customized version of the plugin which will standardize Gradle Enterprise usage across multiple projects
 
-In order for the Common Custom User Gradle plugin to become active, you need to apply it in the `settings.gradle[.kts]` file of your project. The `settings.gradle[.kts]` file is the same file where you have already declared the Gradle Enterprise Gradle plugin. See [here](https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-gradle-plugin/settings.gradle) for an example.
+Out of the box, this plugin will enhance all Build Scans published with additional tags, links and custom values. These include:
+- A tag representing the Operating System.
+- A tag representing how the build was invoked, be that from your IDE (IDEA, Eclipse, Android Studio) or from the command-line.
+- A `CI` tag for builds run on CI. In addition, a set of tags, links and custom values specific to the CI server will be added.
+  - The following CI servers are supported: Jenkins, Team City, Circle CI, Bamboo, GitHub Actions, Gitlab and Travis.
+- For `git` repositories, custom values with the Commit ID, Branch and the output of `git status`
 
-If you are still using a 5.x version of Gradle, apply the Common Custom User Gradle plugin to the `build.gradle[.kts]` file of your root project.
+### Applying the published plugin
+
+The Common Custom User Data Gradle Plugin is available in the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin). This plugin requires the the [Gradle Enterprise Gradle plugin](https://plugins.gradle.org/plugin/com.gradle.enterprise) also be applied in your build in order to have an effect.
+
+To benefit from the Common Custom User Gradle plugin in your project, you must apply it in the `settings.gradle[.kts]` file of your project. This is the same file where you have already declared the Gradle Enterprise Gradle plugin. See [here](https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-gradle-plugin/settings.gradle) for an example.
+
+If you are still using a 5.x version of Gradle, apply the plugin to the `build.gradle[.kts]` file of your root project.
+
+### Developing a customized version of the plugin
+
+For more power and flexibility, we recommend creating a copy of this repository so that you may develop a customized version of the plugin and publish it locally for your projects to consume.
+
+This approach has a number of benefits:
+- Add, remove and change the set of tags, links and custom values added to each Build Scan. This allows you to customize your Build Scans for your particular needs.
+- Standardize Gradle Enterprise and Gradle Build Cache configuration in your organization, removing the need for each project to specify this configuration.
+
+This approach can be particularly useful when Gradle Enterprise and Build Cache configuration should be shared among a number of Gradle projects. If your customized plugin applies the Gradle Enterprise plugin and provides all required configuration, then each consumer project will get all the benefits of Gradle Enterprise simply by applying this single plugin.
+
+See the [Gradle User Manual](https://docs.gradle.org/current/userguide/publishing_gradle_plugins.html#custom-plugin-repositories) for more details on publishing Gradle plugins to an internal repository.
 
 ### Changelog
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -24,7 +24,10 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     private void applySettingsPlugin(Settings settings) {
         settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> {
-            BuildScanExtension buildScan = settings.getExtensions().getByType(GradleEnterpriseExtension.class).getBuildScan();
+            GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
+            CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+
+            BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             CustomBuildScanConfig.configureBuildScan(buildScan, settings.getGradle());
 
             BuildCacheConfiguration buildCache = settings.getBuildCache();
@@ -37,8 +40,12 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             throw new GradleException("Common custom user data plugin may only be applied to root project");
         }
         project.getPluginManager().withPlugin("com.gradle.build-scan", __ -> {
-            BuildScanExtension buildScan = project.getExtensions().getByType(GradleEnterpriseExtension.class).getBuildScan();
+            GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
+            CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+
+            BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             CustomBuildScanConfig.configureBuildScan(buildScan, project.getGradle());
+
             // Build cache configuration cannot be accessed from a project plugin
         });
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanConfig.java
@@ -23,6 +23,9 @@ import static com.gradle.Utils.sysPropertyKeyStartingWith;
 import static com.gradle.Utils.sysPropertyPresent;
 import static com.gradle.Utils.urlEncode;
 
+/**
+ * Adds a standard set of useful tags, links and custom values to all build scans published.
+ */
 final class CustomBuildScanConfig {
 
     static void configureBuildScan(BuildScanExtension buildScan, Gradle gradle) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -1,0 +1,28 @@
+package com.gradle;
+
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
+
+/**
+ * Provide standardized Gradle Enterprise configuration.
+ * By applying the plugin, this Gradle Enterprise configuration will automatically be applied.
+ */
+final class CustomGradleEnterpriseConfig {
+
+    static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise) {
+        /* Example of Gradle Enterprise configuration
+
+        gradleEnterprise.setServer("https://localhost");
+        gradleEnterprise.setAllowUntrustedServer(true);
+
+        gradleEnterprise.buildScan(buildScan -> {
+            buildScan.publishAlways();
+            buildScan.setCaptureTaskInputFiles(true);
+            buildScan.setUploadInBackground(false);
+        });
+
+       */
+    }
+
+    private CustomGradleEnterpriseConfig() {
+    }
+}

--- a/common-custom-user-data-maven-extension/README.md
+++ b/common-custom-user-data-maven-extension/README.md
@@ -2,17 +2,38 @@
 
 ### Overview
 
-The Common Custom User Data Maven Extension for Gradle Enterprise serves multiple purposes:
-- an example how to create custom Maven extension that will standardise your Gradle Enterprise usage
-- a reusable artifact deployed to [Maven Central](https://search.maven.org/artifact/com.gradle/common-custom-user-data-maven-extension) that you can apply to your Maven builds, and it just works
+The Common Custom User Data Maven Extension for Gradle Enterprise enhances published build scans
+by adding a set of tags, links and custom values that have proven to be useful for many users of Gradle Enterprise.
+
+You can leverage this extension for your project in one of two ways:
+1. Apply the published extension directly in your `.mvn/extensions.xml` and immediately benefit from enhanced build scans.
+2. Copy this repository and develop a customized version of the extension which will standardize Gradle Enterprise usage across multiple projects.
+
+Out of the box, this extension enhances all build scans published with additional tags, links and custom values. These include:
+- A tag representing the Operating System.
+- A tag representing how the build was invoked, be that from your IDE (IDEA, Eclipse) or from the command-line.
+- A tag representing builds run on CI, together with a set of tags, links and custom values specific to the CI server running the build.
+- For `git` repositories, information on the commit id, branch name, status, and whether the checkout is dirty or not.
+
+### Using the published extension
+
+The Common Custom User Data Maven Extension is available in [Maven Central](https://search.maven.org/artifact/com.gradle/common-custom-user-data-maven-extension).
+
+The Common Custom User Data Maven Extension requires the [Gradle Enterprise Maven extension](https://search.maven.org/artifact/com.gradle/gradle-enterprise-maven-extension) to already be applied in your build in order to have an effect.
+In order for the Common Custom User Data Maven Extension to become active, you need to register it in the `.mvn/extensions.xml` file in your root project.
+The `extensions.xml` file is the same file where you have already declared the Gradle Enterprise Maven extension. See [here](https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-maven-extension/.mvn/extensions.xml) for an example.
+
+### Developing a customized version of the plugin
+
+For more flexibility, we recommend creating a copy of this repository so that you may develop a customized version of the extension and publish it locally for your projects to consume.
+
+This approach has a number of benefits:
+- Tailor the build scan enhancements to exactly the set of tags, links and custom values you require.
+- Standardize the configuration for connecting to Gradle Enterprise in your organization, removing the need for each project to specify this configuration.
+
+If your customized extension provides all required Gradle Enterprise configuration, then a consumer project will get all the benefits of Gradle Enterprise simply by applying the extension. The plugin sources provide a placeholder and example code to get you started.
 
 Please refer to the [Gradle Enterprise Maven Extension User Manual](https://docs.gradle.com/enterprise/maven-extension/#using_the_common_custom_user_data_maven_extension) for more details.
-
-This plugin requires the [Gradle Enterprise Maven extension](https://search.maven.org/artifact/com.gradle/gradle-enterprise-maven-extension) to already be applied in your build in order to have an effect.
-
-### Usage
-
-In order for the Common Custom User Data Maven extension to become active, you need to register it in the `.mvn/extensions.xml` file in your root project. The `extensions.xml` file is the same file where you have already declared the Gradle Enterprise Maven extension. See [here](https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-maven-extension/.mvn/extensions.xml) for an example.
 
 ### Changelog
 


### PR DESCRIPTION
- Update README for both Gradle Plugin and Maven Extension to describe these it can be used both as a binary plugin/extension and a template for a custom plugin/extension
- Add an example of providing core Gradle Enterprise configuration via the Gradle plugin
