### PR TITLE
Add support for Bitrise CI tagging.

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanConfig.java
@@ -109,7 +109,6 @@ final class CustomBuildScanConfig {
             }
             if (envVariablePresent("CIRCLE_JOB")) {
                 addCustomValueAndSearchLink(buildScan, "CI job", envVariable("CIRCLE_JOB"));
-
             }
             if (envVariablePresent("CIRCLE_WORKFLOW_ID")) {
                 addCustomValueAndSearchLink(buildScan, "CI workflow", envVariable("CIRCLE_WORKFLOW_ID"));
@@ -172,10 +171,19 @@ final class CustomBuildScanConfig {
                 buildScan.tag(envVariable("TRAVIS_EVENT_TYPE"));
             }
         }
+
+        if (isBitrise()) {
+            if (envVariablePresent("BITRISE_BUILD_URL")) {
+                buildScan.link("Bitrise build", envVariable("BITRISE_BUILD_URL"));
+            }
+            if (envVariablePresent("BITRISE_BUILD_NUMBER")) {
+                buildScan.value("CI build number", envVariable("BITRISE_BUILD_NUMBER"));
+            }
+        }
     }
 
     private static boolean isCi() {
-        return isGenericCI() || isJenkins() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis();
+        return isGenericCI() || isJenkins() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis() || isBitrise();
     }
 
     private static boolean isGenericCI() {
@@ -208,6 +216,10 @@ final class CustomBuildScanConfig {
 
     private static boolean isTravis() {
         return envVariablePresent("TRAVIS_JOB_ID");
+    }
+
+    private static boolean isBitrise() {
+        return envVariablePresent("BITRISE_BUILD_NUMBER");
     }
 
     static void captureGitMetadata(BuildScanExtension buildScan) {

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanConfig.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanConfig.java
@@ -85,7 +85,6 @@ final class CustomBuildScanConfig {
             }
             if (envVariablePresent("CIRCLE_JOB")) {
                 addCustomValueAndSearchLink(buildScan, "CI job", envVariable("CIRCLE_JOB"));
-
             }
             if (envVariablePresent("CIRCLE_WORKFLOW_ID")) {
                 addCustomValueAndSearchLink(buildScan, "CI workflow", envVariable("CIRCLE_WORKFLOW_ID"));
@@ -148,10 +147,19 @@ final class CustomBuildScanConfig {
                 buildScan.tag(envVariable("TRAVIS_EVENT_TYPE"));
             }
         }
+
+        if (isBitrise()) {
+            if (envVariablePresent("BITRISE_BUILD_URL")) {
+                buildScan.link("Bitrise build", envVariable("BITRISE_BUILD_URL"));
+            }
+            if (envVariablePresent("BITRISE_BUILD_NUMBER")) {
+                buildScan.value("CI build number", envVariable("BITRISE_BUILD_NUMBER"));
+            }
+        }
     }
 
     private static boolean isCi() {
-        return isGenericCI() || isJenkins() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis();
+        return isGenericCI() || isJenkins() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis() || isBitrise();
     }
 
     private static boolean isGenericCI() {
@@ -184,6 +192,10 @@ final class CustomBuildScanConfig {
 
     private static boolean isTravis() {
         return envVariablePresent("TRAVIS_JOB_ID");
+    }
+
+    private static boolean isBitrise() {
+        return envVariablePresent("BITRISE_BUILD_NUMBER");
     }
 
     static void captureGitMetadata(BuildScanApi buildScan) {


### PR DESCRIPTION
This is based on the environment variables documented here: https://devcenter.bitrise.io/builds/available-environment-variables/

This also tags all builds where the `CI` environment variable is present with the `CI` tag.