### PR TITLE
Supports Hudson CI environments

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -64,7 +64,7 @@ final class CustomBuildScanEnhancements {
     }
 
     private static void captureCiMetadata(BuildScanExtension buildScan) {
-        if (isJenkins()) {
+        if (isJenkins() || isHudson()) {
             if (envVariablePresent("BUILD_URL")) {
                 buildScan.link("Jenkins build", envVariable("BUILD_URL"));
             }
@@ -183,7 +183,7 @@ final class CustomBuildScanEnhancements {
     }
 
     private static boolean isCi() {
-        return isGenericCI() || isJenkins() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis() || isBitrise();
+        return isGenericCI() || isJenkins() || isHudson() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis() || isBitrise();
     }
 
     private static boolean isGenericCI() {
@@ -192,6 +192,10 @@ final class CustomBuildScanEnhancements {
 
     private static boolean isJenkins() {
         return envVariablePresent("JENKINS_URL");
+    }
+
+    private static boolean isHudson() {
+        return envVariablePresent("HUDSON_URL");
     }
 
     private static boolean isTeamCity() {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -64,9 +64,27 @@ final class CustomBuildScanEnhancements {
     }
 
     private static void captureCiMetadata(BuildScanExtension buildScan) {
-        if (isJenkins() || isHudson()) {
+        if (isJenkins()) {
             if (envVariablePresent("BUILD_URL")) {
                 buildScan.link("Jenkins build", envVariable("BUILD_URL"));
+            }
+            if (envVariablePresent("BUILD_NUMBER")) {
+                buildScan.value("CI build number", envVariable("BUILD_NUMBER"));
+            }
+            if (envVariablePresent("NODE_NAME")) {
+                addCustomValueAndSearchLink(buildScan, "CI node", envVariable("NODE_NAME"));
+            }
+            if (envVariablePresent("JOB_NAME")) {
+                addCustomValueAndSearchLink(buildScan, "CI job", envVariable("JOB_NAME"));
+            }
+            if (envVariablePresent("STAGE_NAME")) {
+                addCustomValueAndSearchLink(buildScan, "CI stage", envVariable("STAGE_NAME"));
+            }
+        }
+
+        if (isHudson()) {
+            if (envVariablePresent("BUILD_URL")) {
+                buildScan.link("Hudson build", envVariable("BUILD_URL"));
             }
             if (envVariablePresent("BUILD_NUMBER")) {
                 buildScan.value("CI build number", envVariable("BUILD_NUMBER"));

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -64,27 +64,9 @@ final class CustomBuildScanEnhancements {
     }
 
     private static void captureCiMetadata(BuildScanExtension buildScan) {
-        if (isJenkins()) {
+        if (isJenkins() || isHudson()) {
             if (envVariablePresent("BUILD_URL")) {
-                buildScan.link("Jenkins build", envVariable("BUILD_URL"));
-            }
-            if (envVariablePresent("BUILD_NUMBER")) {
-                buildScan.value("CI build number", envVariable("BUILD_NUMBER"));
-            }
-            if (envVariablePresent("NODE_NAME")) {
-                addCustomValueAndSearchLink(buildScan, "CI node", envVariable("NODE_NAME"));
-            }
-            if (envVariablePresent("JOB_NAME")) {
-                addCustomValueAndSearchLink(buildScan, "CI job", envVariable("JOB_NAME"));
-            }
-            if (envVariablePresent("STAGE_NAME")) {
-                addCustomValueAndSearchLink(buildScan, "CI stage", envVariable("STAGE_NAME"));
-            }
-        }
-
-        if (isHudson()) {
-            if (envVariablePresent("BUILD_URL")) {
-                buildScan.link("Hudson build", envVariable("BUILD_URL"));
+                buildScan.link(isJenkins() ? "Jenkins build" : "Hudson build", envVariable("BUILD_URL"));
             }
             if (envVariablePresent("BUILD_NUMBER")) {
                 buildScan.value("CI build number", envVariable("BUILD_NUMBER"));

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -6,7 +6,17 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.gradle.Utils.*;
+import static com.gradle.Utils.appendIfMissing;
+import static com.gradle.Utils.envVariable;
+import static com.gradle.Utils.envVariablePresent;
+import static com.gradle.Utils.execAndCheckSuccess;
+import static com.gradle.Utils.execAndGetStdOut;
+import static com.gradle.Utils.isNotEmpty;
+import static com.gradle.Utils.readPropertiesFile;
+import static com.gradle.Utils.sysProperty;
+import static com.gradle.Utils.sysPropertyKeyStartingWith;
+import static com.gradle.Utils.sysPropertyPresent;
+import static com.gradle.Utils.urlEncode;
 
 /**
  * Adds a standard set of useful tags, links and custom values to all build scans published.
@@ -40,9 +50,9 @@ final class CustomBuildScanEnhancements {
     }
 
     private static void captureCiMetadata(BuildScanApi buildScan) {
-        if (isJenkins()) {
+        if (isJenkins() || isHudson()) {
             if (envVariablePresent("BUILD_URL")) {
-                buildScan.link("Jenkins build", envVariable("BUILD_URL"));
+                buildScan.link(isJenkins() ? "Jenkins build" : "Hudson build", envVariable("BUILD_URL"));
             }
             if (envVariablePresent("BUILD_NUMBER")) {
                 buildScan.value("CI build number", envVariable("BUILD_NUMBER"));
@@ -168,6 +178,10 @@ final class CustomBuildScanEnhancements {
 
     private static boolean isJenkins() {
         return envVariablePresent("JENKINS_URL");
+    }
+
+    private static boolean isHudson() {
+        return envVariablePresent("HUDSON_URL");
     }
 
     private static boolean isTeamCity() {


### PR DESCRIPTION
Uses the `HUDSON_URL` environment variable set by Hudson CI to determine
if build is being run by a CI instance and to capture CI metadata.