### PR TITLE
Fix TeamCity integration

### DIFF
--- a/common-custom-user-data-gradle-plugin/CHANGELOG.md
+++ b/common-custom-user-data-gradle-plugin/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Detect generic "CI" environment variable or system property to add `CI` tag
+### Fixed
+- Capture TeamCity link and values based on environment variables that are present in TeamCity 2020.2
 
 ## [1.1.1] - 2021-01-26
 ### Fixed

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -7,7 +7,6 @@ import org.gradle.api.Task;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.tasks.testing.Test;
 
-import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -83,20 +82,14 @@ final class CustomBuildScanEnhancements {
         }
 
         if (isTeamCity()) {
-            if (sysPropertyPresent("teamcity.configuration.properties.file")) {
-                Properties properties = readPropertiesFile(sysProperty("teamcity.configuration.properties.file"));
-                String teamCityServerUrl = properties.getProperty("teamcity.serverUrl");
-                if (teamCityServerUrl != null && sysPropertyPresent("build.number") && sysPropertyPresent("teamcity.buildType.id")) {
-                    String buildNumber = sysProperty("build.number");
-                    String buildTypeId = sysProperty("teamcity.buildType.id");
-                    buildScan.link("TeamCity build", appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildNumber=" + buildNumber + "&buildTypeId=" + buildTypeId);
-                }
+            if (envVariablePresent("BUILD_URL")) {
+                buildScan.link("TeamCity build", envVariable("BUILD_URL"));
             }
-            if (sysPropertyPresent("build.number")) {
-                buildScan.value("CI build number", sysProperty("build.number"));
+            if (envVariablePresent("BUILD_NUMBER")) {
+                buildScan.value("CI build number", envVariable("BUILD_NUMBER"));
             }
-            if (sysPropertyPresent("agent.name")) {
-                addCustomValueAndSearchLink(buildScan, "CI agent", sysProperty("agent.name"));
+            if (envVariablePresent("BUILD_AGENT_NAME")) {
+                addCustomValueAndSearchLink(buildScan, "CI agent", envVariable("BUILD_AGENT_NAME"));
             }
         }
 

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -2,7 +2,6 @@ package com.gradle;
 
 import com.gradle.maven.extension.api.scan.BuildScanApi;
 
-import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -59,20 +58,14 @@ final class CustomBuildScanEnhancements {
         }
 
         if (isTeamCity()) {
-            if (sysPropertyPresent("teamcity.configuration.properties.file")) {
-                Properties properties = readPropertiesFile(sysProperty("teamcity.configuration.properties.file"));
-                String teamCityServerUrl = properties.getProperty("teamcity.serverUrl");
-                if (teamCityServerUrl != null && sysPropertyPresent("build.number") && sysPropertyPresent("teamcity.buildType.id")) {
-                    String buildNumber = sysProperty("build.number");
-                    String buildTypeId = sysProperty("teamcity.buildType.id");
-                    buildScan.link("TeamCity build", appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildNumber=" + buildNumber + "&buildTypeId=" + buildTypeId);
-                }
+            if (envVariablePresent("BUILD_URL")) {
+                buildScan.link("TeamCity build", envVariable("BUILD_URL"));
             }
-            if (sysPropertyPresent("build.number")) {
-                buildScan.value("CI build number", sysProperty("build.number"));
+            if (envVariablePresent("BUILD_NUMBER")) {
+                buildScan.value("CI build number", envVariable("BUILD_NUMBER"));
             }
-            if (sysPropertyPresent("agent.name")) {
-                addCustomValueAndSearchLink(buildScan, "CI agent", sysProperty("agent.name"));
+            if (envVariablePresent("BUILD_AGENT_NAME")) {
+                addCustomValueAndSearchLink(buildScan, "CI agent", envVariable("BUILD_AGENT_NAME"));
             }
         }
 


### PR DESCRIPTION
The TeamCity 2020.2.2 no system properties are added to the build invocation
making our integration non-functional. This fix instead relies on env vars
to integrate with TeamCity.