### PR TITLE
Tell shellcheck to process included scripts when processing scripts

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -13,6 +13,7 @@ jobs:
       uses: luizm/action-sh-checker@v0.1.12
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SHELLCHECK_OPTS: -x
       with:
         sh_checker_comment: true
         sh_checker_exclude: "gradlew mvnw"


### PR DESCRIPTION
The experiment scripts include other scripts, and so not using -x causes
shellcheck to fail on those files.