### PR TITLE
Tweak how shellcheck is run

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,7 +1,9 @@
 name: 'Shellcheck'
 
 on:
-  push
+  push:
+  pull_request:
+    types: [synchronize]
 
 jobs:
   shellcheck:


### PR DESCRIPTION
If we trigger shellcheck on a pull-request event, then whatever it finds will be added as a comment to the pull-request, which is pretty nice.

This causes the check to run twice (once on the push event, and once on the pull-request event), but there isn't any significant downside to that.