### PR TITLE
Add support for configuring Gradle Enterprise settings via system properties

### DIFF
--- a/common-custom-user-data-gradle-plugin/README.md
+++ b/common-custom-user-data-gradle-plugin/README.md
@@ -16,7 +16,7 @@ Out of the box, this plugin enhances all build scans published with additional t
 - For `git` repositories, information on the commit id, branch name, status, and whether the checkout is dirty or not.
 
 Out of the box, this plugin also allows users to override various Gradle Enterprise, build scan, and build caching settings via
-system properties.
+system properties (see [Overriding Gradle Enterprise configuration values via system properties](#overriding_gradle_enterprise_configuration_values_via_system_properties)).
 
 ### Applying the published plugin
 
@@ -81,6 +81,7 @@ The Gradle Enterprise plugin directly supports two other system properties:
 |`scan.captureTaskInputFiles`               | `true` or `false`   | Enables/disables capturing task input files in build scans.
 |`scan.uploadInBackground`                  | `true` or `false`   | Enables/disables uploading build scans in the background.
 
+See the [Gradle Enterprise Gradle Plugin User Manual](https://docs.gradle.com/enterprise/gradle-plugin/) for more details.
 
 ### Developing a customized version of the plugin
 

--- a/common-custom-user-data-gradle-plugin/README.md
+++ b/common-custom-user-data-gradle-plugin/README.md
@@ -15,6 +15,9 @@ Out of the box, this plugin enhances all build scans published with additional t
 - A tag representing builds run on CI, together with a set of tags, links and custom values specific to the CI server running the build.
 - For `git` repositories, information on the commit id, branch name, status, and whether the checkout is dirty or not.
 
+Out of the box, this plugin also allows users to override various Gradle Enterprise, build scan, and build caching settings via
+system properties.
+
 ### Applying the published plugin
 
 The Common Custom User Data Gradle Plugin is available in the [Gradle Plugin Portal](https://plugins.gradle.org/plugin/com.gradle.common-custom-user-data-gradle-plugin). This plugin
@@ -45,6 +48,40 @@ plugins {
     // …
 }
 ```
+
+### Overriding Gradle Enterprise configuration values via system properties
+
+The Common Custom User Data Gradle Plugin adds the ability to override many Gradle Enterprise settings via system properties.
+You can use the system properties to override Gradle Enterprise settings temporarily, such as while performing a
+[build validation experiment](../build-validation) or as a troubleshooting step while investigating a problem.
+
+The following system properties are supported:
+
+|System Property                            | Acceptable Values   | Description
+|-------------------------------------------|---------------------|------------
+|`gradle.enterprise.url`                    | URL                 | Sets the URL of the Gradle Enterprise server, primarily for publishing build scans.
+|`gradle.cache.local.enabled`               | `true` or `false`   | Enables/disables the local build cache.
+|`gradle.cache.local.directory`             | path to a directory | Sets the location of the local build cache.
+|`gradle.cache.local.cleanup.enabled`       | `true` or `false`   | Enables/disables cleanup of the local build cache. If set to true, then the cleanup retention is set to Integer.MAX_INT days.
+|`gradle.cache.local.cleanup.retention`     | [Duration String Representation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)) | Sets how long local build cache entries are allowed to exist before they are deleted automatically.
+|`gradle.cache.remote.enabled`              | `true` or `false`   | Enables/disables the remote build cache.
+|`gradle.cache.remote.url`                  | URL | Sets the URL of the remote cache node. Assumes the remote cache is a HTTPBuildCache.
+|`gradle.cache.remote.storeEnabled`         | `true` or `false`   | Enables/disables pushing (storing) new entries in the remote build cache.
+|`gradle.cache.remote.allowUntrustedServer` | `true` or `false`   | Enables/disables accepting insecure (e.g., self-signed) SSL certificates when connecting to the remote build cache node via HTTPS.
+
+For example, to change the Gradle Enterprise server used, and to disable the local build cache:
+
+```bash
+./gradlew -Dgradle.enterprise.url=https://example.com -Dgradle.cache.local.enabled=false build
+```
+
+The Gradle Enterprise plugin directly supports two other system properties:
+
+|System Property                            | Acceptable Values   | Description
+|-------------------------------------------|---------------------|------------
+|`scan.captureTaskInputFiles`               | `true` or `false`   | Enables/disables capturing task input files in build scans.
+|`scan.uploadInBackground`                  | `true` or `false`   | Enables/disables uploading build scans in the background.
+
 
 ### Developing a customized version of the plugin
 

--- a/common-custom-user-data-gradle-plugin/README.md
+++ b/common-custom-user-data-gradle-plugin/README.md
@@ -62,11 +62,10 @@ The following system properties are supported:
 |`gradle.enterprise.url`                    | URL                 | Sets the URL of the Gradle Enterprise server, primarily for publishing build scans.
 |`gradle.cache.local.enabled`               | `true` or `false`   | Enables/disables the local build cache.
 |`gradle.cache.local.directory`             | path to a directory | Sets the location of the local build cache.
-|`gradle.cache.local.cleanup.enabled`       | `true` or `false`   | Enables/disables cleanup of the local build cache. If set to true, then the cleanup retention is set to Integer.MAX_INT days.
-|`gradle.cache.local.cleanup.retention`     | [Duration String Representation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)) | Sets how long local build cache entries are allowed to exist before they are deleted automatically.
+|`gradle.cache.local.removeUnusedEntriesAfterDays` | [Duration String Representation](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/time/Duration.html#parse(java.lang.CharSequence)) | Sets how long local build cache entries are allowed to exist before they are deleted automatically.
 |`gradle.cache.remote.enabled`              | `true` or `false`   | Enables/disables the remote build cache.
 |`gradle.cache.remote.url`                  | URL | Sets the URL of the remote cache node. Assumes the remote cache is a HTTPBuildCache.
-|`gradle.cache.remote.storeEnabled`         | `true` or `false`   | Enables/disables pushing (storing) new entries in the remote build cache.
+|`gradle.cache.remote.push`                 | `true` or `false`   | Enables/disables pushing (storing) new entries in the remote build cache.
 |`gradle.cache.remote.allowUntrustedServer` | `true` or `false`   | Enables/disables accepting insecure (e.g., self-signed) SSL certificates when connecting to the remote build cache node via HTTPS.
 
 For example, to change the Gradle Enterprise server used, and to disable the local build cache:

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -36,6 +36,12 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     private void applySettingsPlugin(Settings settings) {
         settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> {
+            // Applies configuration changes after any settings in the project's settings.gradle(.kts) has been evaluated.
+            // This means that any configuration changes applied here will override configuration settings set in the
+            // settings.gradle.
+            ///
+            // Unwrap this block (delete the next line) to instead allow the project's settings.gradle to override
+            // settings set by this plugin.
             settings.getGradle().settingsEvaluated(___ -> {
                 GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
                 customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
@@ -55,6 +61,12 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             throw new GradleException("Common custom user data plugin may only be applied to root project");
         }
         project.getPluginManager().withPlugin("com.gradle.build-scan", __ -> {
+            // Applies configuration changes after any settings in the project's build.gradle(.kts) has been evaluated.
+            // This means that any configuration changes applied here will override configuration settings set in the
+            // build script.
+            ///
+            // Unwrap this block (delete the next line) to instead allow the project's build script to override
+            // settings set by this plugin.
             project.afterEvaluate(___ -> {
                 GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
                 customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -47,8 +47,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             BuildCacheConfiguration buildCache = settings.getBuildCache();
             CustomGradleEnterpriseConfig.configureBuildCache(buildCache);
 
+            // configuration changes applied in this block will override earlier configuration settings (including those set in the settings.gradle(.kts))
             settings.getGradle().settingsEvaluated(___ -> {
-                // configuration changes applied here will override earlier configuration settings (including those set in the settings.gradle(.kts))
                 SystemPropertyOverrides.configureGradleEnterprise(gradleEnterprise, providers);
                 SystemPropertyOverrides.configureBuildCache(buildCache, providers);
             });
@@ -69,8 +69,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
             // Build cache configuration cannot be accessed from a project plugin
 
+            // configuration changes applied within this block will override earlier configuration settings (including those set in the settings.gradle(.kts))
             project.afterEvaluate(___ -> {
-                // configuration changes applied here will override earlier configuration settings (including those set in the settings.gradle(.kts))
                 SystemPropertyOverrides.configureGradleEnterprise(gradleEnterprise, providers);
             });
         });

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -36,15 +36,17 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     private void applySettingsPlugin(Settings settings) {
         settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> {
-            GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
-            customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+            settings.getGradle().settingsEvaluated(___ -> {
+                GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
+                customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
-            BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-            customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            CustomBuildScanEnhancements.configureBuildScan(buildScan, settings.getGradle());
+                BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
+                customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+                CustomBuildScanEnhancements.configureBuildScan(buildScan, settings.getGradle());
 
-            BuildCacheConfiguration buildCache = settings.getBuildCache();
-            customGradleEnterpriseConfig.configureBuildCache(buildCache);
+                BuildCacheConfiguration buildCache = settings.getBuildCache();
+                customGradleEnterpriseConfig.configureBuildCache(buildCache);
+            });
         });
     }
 
@@ -53,14 +55,16 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             throw new GradleException("Common custom user data plugin may only be applied to root project");
         }
         project.getPluginManager().withPlugin("com.gradle.build-scan", __ -> {
-            GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
-            customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+            project.afterEvaluate(___ -> {
+                GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
+                customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
-            BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-            customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            CustomBuildScanEnhancements.configureBuildScan(buildScan, project.getGradle());
+                BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
+                customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+                CustomBuildScanEnhancements.configureBuildScan(buildScan, project.getGradle());
 
-            // Build cache configuration cannot be accessed from a project plugin
+                // Build cache configuration cannot be accessed from a project plugin
+            });
         });
     }
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -13,6 +13,7 @@ import org.gradle.util.GradleVersion;
 import javax.inject.Inject;
 
 public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
+
     private final CustomGradleEnterpriseConfig customGradleEnterpriseConfig;
 
     @Inject
@@ -80,7 +81,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         });
     }
 
-    private boolean isGradle6OrNewer() {
+    private static boolean isGradle6OrNewer() {
         return GradleVersion.current().compareTo(GradleVersion.version("6.0")) >= 0;
     }
+
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -37,12 +37,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
     private void applySettingsPlugin(Settings settings) {
         settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> {
-            // Applies configuration changes after any settings in the project's settings.gradle(.kts) has been evaluated.
-            // This means that any configuration changes applied here will override configuration settings set in the
-            // settings.gradle.
-            ///
-            // Unwrap this block (delete the next line) to instead allow the project's settings.gradle to override
-            // settings set by this plugin.
+            // configuration changes applied here will override configuration settings set in the settings.gradle(.kts)
+            // unwrap this block to instead allow the project's settings.gradle(.kts) to override the configuration settings set by this plugin
             settings.getGradle().settingsEvaluated(___ -> {
                 GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
                 CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise, providers);
@@ -62,12 +58,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             throw new GradleException("Common custom user data plugin may only be applied to root project");
         }
         project.getPluginManager().withPlugin("com.gradle.build-scan", __ -> {
-            // Applies configuration changes after any settings in the project's build.gradle(.kts) has been evaluated.
-            // This means that any configuration changes applied here will override configuration settings set in the
-            // build script.
-            ///
-            // Unwrap this block (delete the next line) to instead allow the project's build script to override
-            // settings set by this plugin.
+            // configuration changes applied here will override configuration settings set in the root project's build.gradle(.kts)
+            // unwrap this block to instead allow the root project's build.gradle(.kts) to override the configuration settings set by this plugin
             project.afterEvaluate(___ -> {
                 GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
                 CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise, providers);

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -14,11 +14,11 @@ import javax.inject.Inject;
 
 public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
-    private final CustomGradleEnterpriseConfig customGradleEnterpriseConfig;
+    private final ProviderFactory providers;
 
     @Inject
     public CommonCustomUserDataGradlePlugin(ProviderFactory providers) {
-        this.customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig(providers);
+        this.providers = providers;
     }
 
     public void apply(Object target) {
@@ -45,14 +45,14 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             // settings set by this plugin.
             settings.getGradle().settingsEvaluated(___ -> {
                 GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
-                customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+                CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise, providers);
 
                 BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-                customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+                CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan, providers);
                 CustomBuildScanEnhancements.configureBuildScan(buildScan, settings.getGradle());
 
                 BuildCacheConfiguration buildCache = settings.getBuildCache();
-                customGradleEnterpriseConfig.configureBuildCache(buildCache);
+                CustomGradleEnterpriseConfig.configureBuildCache(buildCache, providers);
             });
         });
     }
@@ -70,10 +70,10 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             // settings set by this plugin.
             project.afterEvaluate(___ -> {
                 GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
-                customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+                CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise, providers);
 
                 BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-                customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+                CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan, providers);
                 CustomBuildScanEnhancements.configureBuildScan(buildScan, project.getGradle());
 
                 // Build cache configuration cannot be accessed from a project plugin

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -6,10 +6,20 @@ import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.initialization.Settings;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.util.GradleVersion;
 
+import javax.inject.Inject;
+
 public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
+    private final CustomGradleEnterpriseConfig customGradleEnterpriseConfig;
+
+    @Inject
+    public CommonCustomUserDataGradlePlugin(ProviderFactory providers) {
+        this.customGradleEnterpriseConfig = new CustomGradleEnterpriseConfig(providers);
+    }
+
     public void apply(Object target) {
         if (target instanceof Settings) {
             if (!isGradle6OrNewer()) {
@@ -27,14 +37,14 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
     private void applySettingsPlugin(Settings settings) {
         settings.getPluginManager().withPlugin("com.gradle.enterprise", __ -> {
             GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
-            CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+            customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-            CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+            customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
             CustomBuildScanEnhancements.configureBuildScan(buildScan, settings.getGradle());
 
             BuildCacheConfiguration buildCache = settings.getBuildCache();
-            CustomGradleEnterpriseConfig.configureBuildCache(buildCache);
+            customGradleEnterpriseConfig.configureBuildCache(buildCache);
         });
     }
 
@@ -44,10 +54,10 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
         }
         project.getPluginManager().withPlugin("com.gradle.build-scan", __ -> {
             GradleEnterpriseExtension gradleEnterprise = project.getExtensions().getByType(GradleEnterpriseExtension.class);
-            CustomGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
+            customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-            CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+            customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
             CustomBuildScanEnhancements.configureBuildScan(buildScan, project.getGradle());
 
             // Build cache configuration cannot be accessed from a project plugin

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -1,7 +1,6 @@
 package com.gradle;
 
 import com.gradle.scan.plugin.BuildScanExtension;
-
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -13,7 +12,15 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.gradle.Utils.*;
+import static com.gradle.Utils.appendIfMissing;
+import static com.gradle.Utils.envVariable;
+import static com.gradle.Utils.execAndCheckSuccess;
+import static com.gradle.Utils.execAndGetStdOut;
+import static com.gradle.Utils.isNotEmpty;
+import static com.gradle.Utils.readPropertiesFile;
+import static com.gradle.Utils.sysProperty;
+import static com.gradle.Utils.sysPropertyKeyStartingWith;
+import static com.gradle.Utils.urlEncode;
 
 /**
  * Adds a standard set of useful tags, links and custom values to all build scans published.
@@ -64,15 +71,15 @@ final class CustomBuildScanEnhancements {
     private static void captureCiMetadata(BuildScanExtension buildScan, Gradle gradle) {
         if (isJenkins() || isHudson()) {
             envVariable("BUILD_URL").ifPresent(url ->
-                    buildScan.link(isJenkins() ? "Jenkins build" : "Hudson build", url));
+                buildScan.link(isJenkins() ? "Jenkins build" : "Hudson build", url));
             envVariable("BUILD_NUMBER").ifPresent(value ->
-                    buildScan.value("CI build number", value));
+                buildScan.value("CI build number", value));
             envVariable("NODE_NAME").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI node", value));
+                addCustomValueAndSearchLink(buildScan, "CI node", value));
             envVariable("JOB_NAME").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI job", value));
+                addCustomValueAndSearchLink(buildScan, "CI job", value));
             envVariable("STAGE_NAME").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI stage", value));
+                addCustomValueAndSearchLink(buildScan, "CI stage", value));
         }
 
         if (isTeamCity()) {
@@ -82,8 +89,8 @@ final class CustomBuildScanEnhancements {
                 Optional<String> buildNumber = projectProperty(gradle, "build.number");
                 Optional<String> buildTypeId = projectProperty(gradle, "teamcity.buildType.id");
                 if (teamCityConfigFile.isPresent()
-                        && buildNumber.isPresent()
-                        && buildTypeId.isPresent()) {
+                    && buildNumber.isPresent()
+                    && buildTypeId.isPresent()) {
                     Properties properties = readPropertiesFile(teamCityConfigFile.get());
                     String teamCityServerUrl = properties.getProperty("teamcity.serverUrl");
                     if (teamCityServerUrl != null) {
@@ -92,36 +99,36 @@ final class CustomBuildScanEnhancements {
                     }
                 }
                 buildNumber.ifPresent(value ->
-                        buildScan.value("CI build number", value));
+                    buildScan.value("CI build number", value));
                 buildTypeId.ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI build config", value));
+                    addCustomValueAndSearchLink(buildScan, "CI build config", value));
                 projectProperty(gradle, "agent.name").ifPresent(value ->
-                        addCustomValueAndSearchLink(buildScan, "CI agent", value));
+                    addCustomValueAndSearchLink(buildScan, "CI agent", value));
             });
         }
 
         if (isCircleCI()) {
             envVariable("CIRCLE_BUILD_URL").ifPresent(url ->
-                    buildScan.link("CircleCI build", url));
+                buildScan.link("CircleCI build", url));
             envVariable("CIRCLE_BUILD_NUM").ifPresent(value ->
-                    buildScan.value("CI build number", value));
+                buildScan.value("CI build number", value));
             envVariable("CIRCLE_JOB").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI job", value));
+                addCustomValueAndSearchLink(buildScan, "CI job", value));
             envVariable("CIRCLE_WORKFLOW_ID").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI workflow", value));
+                addCustomValueAndSearchLink(buildScan, "CI workflow", value));
         }
 
         if (isBamboo()) {
             envVariable("bamboo_resultsUrl").ifPresent(url ->
-                    buildScan.link("Bamboo build", url));
+                buildScan.link("Bamboo build", url));
             envVariable("bamboo_buildNumber").ifPresent(value ->
-                    buildScan.value("CI build number", value));
+                buildScan.value("CI build number", value));
             envVariable("bamboo_planName").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI plan", value));
+                addCustomValueAndSearchLink(buildScan, "CI plan", value));
             envVariable("bamboo_buildPlanName").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI build plan", value));
+                addCustomValueAndSearchLink(buildScan, "CI build plan", value));
             envVariable("bamboo_agentId").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI agent", value));
+                addCustomValueAndSearchLink(buildScan, "CI agent", value));
         }
 
         if (isGitHubActions()) {
@@ -131,35 +138,35 @@ final class CustomBuildScanEnhancements {
                 buildScan.link("GitHub Actions build", "https://github.com/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
             }
             envVariable("GITHUB_WORKFLOW").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "GitHub workflow", value));
+                addCustomValueAndSearchLink(buildScan, "GitHub workflow", value));
         }
 
         if (isGitLab()) {
             envVariable("CI_JOB_URL").ifPresent(url ->
-                    buildScan.link("GitLab build", url));
+                buildScan.link("GitLab build", url));
             envVariable("CI_PIPELINE_URL").ifPresent(url ->
-                    buildScan.link("GitLab pipeline", url));
+                buildScan.link("GitLab pipeline", url));
             envVariable("CI_JOB_NAME").ifPresent(value1 ->
-                    addCustomValueAndSearchLink(buildScan, "CI job", value1));
+                addCustomValueAndSearchLink(buildScan, "CI job", value1));
             envVariable("CI_JOB_STAGE").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI stage", value));
+                addCustomValueAndSearchLink(buildScan, "CI stage", value));
         }
 
         if (isTravis()) {
             envVariable("TRAVIS_BUILD_WEB_URL").ifPresent(url ->
-                    buildScan.link("Travis build", url));
+                buildScan.link("Travis build", url));
             envVariable("TRAVIS_BUILD_NUMBER").ifPresent(value ->
-                    buildScan.value("CI build number", value));
+                buildScan.value("CI build number", value));
             envVariable("TRAVIS_JOB_NAME").ifPresent(value ->
-                    addCustomValueAndSearchLink(buildScan, "CI job", value));
+                addCustomValueAndSearchLink(buildScan, "CI job", value));
             envVariable("TRAVIS_EVENT_TYPE").ifPresent(buildScan::tag);
         }
 
         if (isBitrise()) {
             envVariable("BITRISE_BUILD_URL").ifPresent(url ->
-                    buildScan.link("Bitrise build", url));
+                buildScan.link("Bitrise build", url));
             envVariable("BITRISE_BUILD_NUMBER").ifPresent(value ->
-                    buildScan.value("CI build number", value));
+                buildScan.value("CI build number", value));
         }
     }
 
@@ -218,29 +225,29 @@ final class CustomBuildScanEnhancements {
             String gitBranchName = execAndGetStdOut("git", "rev-parse", "--abbrev-ref", "HEAD");
             String gitStatus = execAndGetStdOut("git", "status", "--porcelain");
 
-            if (gitCommitId != null) {
-                addCustomValueAndSearchLink(buildScan, "Git commit id", gitCommitId);
-
-                if (isNotEmpty(gitRepo)) {
-                    if (gitRepo.contains("github.com/") || gitRepo.contains("github.com:")) {
-                        Matcher matcher = Pattern.compile("(.*)github\\.com[/|:](.*)").matcher(gitRepo);
-                        if (matcher.matches()) {
-                            String rawRepoPath = matcher.group(2);
-                            String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
-                            api.link("Github source", "https://github.com/" + repoPath + "/tree/" + gitCommitId);
-                        }
-                    } else if (gitRepo.contains("gitlab.com/") || gitRepo.contains("gitlab.com:")) {
-                        Matcher matcher = Pattern.compile("(.*)gitlab\\.com[/|:](.*)").matcher(gitRepo);
-                        if (matcher.matches()) {
-                            String rawRepoPath = matcher.group(2);
-                            String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
-                            api.link("GitLab Source", "https://gitlab.com/" + repoPath + "/-/commit/" + gitCommitId);
-                        }
+            if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
+                if (gitRepo.contains("github.com/") || gitRepo.contains("github.com:")) {
+                    Matcher matcher = Pattern.compile("(.*)github\\.com[/|:](.*)").matcher(gitRepo);
+                    if (matcher.matches()) {
+                        String rawRepoPath = matcher.group(2);
+                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
+                        api.link("Github source", "https://github.com/" + repoPath + "/tree/" + gitCommitId);
+                    }
+                } else if (gitRepo.contains("gitlab.com/") || gitRepo.contains("gitlab.com:")) {
+                    Matcher matcher = Pattern.compile("(.*)gitlab\\.com[/|:](.*)").matcher(gitRepo);
+                    if (matcher.matches()) {
+                        String rawRepoPath = matcher.group(2);
+                        String repoPath = rawRepoPath.endsWith(".git") ? rawRepoPath.substring(0, rawRepoPath.length() - 4) : rawRepoPath;
+                        api.link("GitLab Source", "https://gitlab.com/" + repoPath + "/-/commit/" + gitCommitId);
                     }
                 }
             }
+
             if (isNotEmpty(gitRepo)) {
                 api.value("Git repository", gitRepo);
+            }
+            if (isNotEmpty(gitCommitId)) {
+                addCustomValueAndSearchLink(buildScan, "Git commit id", gitCommitId);
             }
             if (isNotEmpty(gitBranchName)) {
                 api.tag(gitBranchName);
@@ -259,15 +266,15 @@ final class CustomBuildScanEnhancements {
 
     private static void captureTestParallelization(BuildScanExtension buildScan, Gradle gradle) {
         gradle.allprojects(p ->
-                p.getTasks().withType(Test.class).configureEach(test ->
-                        test.doFirst(new Action<Task>() {
-                            // use anonymous inner class to keep Test task instance cacheable
-                            @Override
-                            public void execute(Task task) {
-                                buildScan.value(test.getIdentityPath() + "#maxParallelForks", String.valueOf(test.getMaxParallelForks()));
-                            }
-                        })
-                )
+            p.getTasks().withType(Test.class).configureEach(test ->
+                test.doFirst(new Action<Task>() {
+                    // use anonymous inner class to keep Test task instance cacheable
+                    @Override
+                    public void execute(Task task) {
+                        buildScan.value(test.getIdentityPath() + "#maxParallelForks", String.valueOf(test.getMaxParallelForks()));
+                    }
+                })
+            )
         );
     }
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -225,6 +225,21 @@ final class CustomBuildScanEnhancements {
             String gitBranchName = execAndGetStdOut("git", "rev-parse", "--abbrev-ref", "HEAD");
             String gitStatus = execAndGetStdOut("git", "status", "--porcelain");
 
+            if (isNotEmpty(gitRepo)) {
+                api.value("Git repository", gitRepo);
+            }
+            if (isNotEmpty(gitCommitId)) {
+                addCustomValueAndSearchLink(buildScan, "Git commit id", gitCommitId);
+            }
+            if (isNotEmpty(gitBranchName)) {
+                api.tag(gitBranchName);
+                api.value("Git branch", gitBranchName);
+            }
+            if (isNotEmpty(gitStatus)) {
+                api.tag("Dirty");
+                api.value("Git status", gitStatus);
+            }
+
             if (isNotEmpty(gitRepo) && isNotEmpty(gitCommitId)) {
                 if (gitRepo.contains("github.com/") || gitRepo.contains("github.com:")) {
                     Matcher matcher = Pattern.compile("(.*)github\\.com[/|:](.*)").matcher(gitRepo);
@@ -241,21 +256,6 @@ final class CustomBuildScanEnhancements {
                         api.link("GitLab Source", "https://gitlab.com/" + repoPath + "/-/commit/" + gitCommitId);
                     }
                 }
-            }
-
-            if (isNotEmpty(gitRepo)) {
-                api.value("Git repository", gitRepo);
-            }
-            if (isNotEmpty(gitCommitId)) {
-                addCustomValueAndSearchLink(buildScan, "Git commit id", gitCommitId);
-            }
-            if (isNotEmpty(gitBranchName)) {
-                api.tag(gitBranchName);
-                api.value("Git branch", gitBranchName);
-            }
-            if (isNotEmpty(gitStatus)) {
-                api.tag("Dirty");
-                api.value("Git status", gitStatus);
             }
         });
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -106,15 +106,10 @@ final class CustomGradleEnterpriseConfig {
     }
 
     private void withSystemProp(String systemPropertyName, Consumer<String> action) {
-        Provider<String> prop = providers.systemProperty(systemPropertyName).forUseAtConfigurationTime();
-        if(prop.isPresent()) {
-            action.accept(prop.get());
-        }
+        Utils.withSystemProp(providers, systemPropertyName, action);
     }
 
     private void withBooleanSystemProp(String systemPropertyName, Consumer<Boolean> action) {
-        withSystemProp(systemPropertyName, value -> {
-            action.accept(parseBoolean(value));
-        });
+        Utils.withBooleanSystemProp(providers, systemPropertyName, action);
     }
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -27,13 +27,7 @@ final class CustomGradleEnterpriseConfig {
     public static final String REMOTE_CACHE_PUSH_ENABLED_PROP = "gradle.cache.remote.storeEnabled";
     public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP = "gradle.cache.remote.allowUntrustedServer";
 
-    private final ProviderFactory providers;
-
-    CustomGradleEnterpriseConfig(ProviderFactory providers) {
-        this.providers = providers;
-    }
-
-    void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise) {
+    static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers) {
         /* Example of Gradle Enterprise configuration
 
         gradleEnterprise.setServer("https://your-gradle-enterprise-server.com");
@@ -42,7 +36,7 @@ final class CustomGradleEnterpriseConfig {
         withSysProperty(providers, GRADLE_ENTERPRISE_URL_PROP, gradleEnterprise::setServer);
     }
 
-    void configureBuildScanPublishing(BuildScanExtension buildScan) {
+    static void configureBuildScanPublishing(BuildScanExtension buildScan, ProviderFactory providers) {
         /* Example of build scan publishing configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -54,7 +48,7 @@ final class CustomGradleEnterpriseConfig {
         */
     }
 
-    void configureBuildCache(BuildCacheConfiguration buildCache) {
+    static void configureBuildCache(BuildCacheConfiguration buildCache, ProviderFactory providers) {
         /* Example of build cache configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -95,6 +89,9 @@ final class CustomGradleEnterpriseConfig {
             withBooleanSysProperty(providers, REMOTE_CACHE_PUSH_ENABLED_PROP, remote::setPush);
             withBooleanSysProperty(providers, REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, remote::setAllowUntrustedServer);
         });
+    }
+
+    private CustomGradleEnterpriseConfig() {
     }
 
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -33,7 +33,7 @@ final class CustomGradleEnterpriseConfig {
         this.providers = providers;
     }
 
-    public void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise) {
+    void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise) {
         /* Example of Gradle Enterprise configuration
 
         gradleEnterprise.setServer("https://your-gradle-enterprise-server.com");
@@ -42,7 +42,7 @@ final class CustomGradleEnterpriseConfig {
         withSysProperty(providers, GRADLE_ENTERPRISE_URL_PROP, gradleEnterprise::setServer);
     }
 
-    public void configureBuildScanPublishing(BuildScanExtension buildScan) {
+    void configureBuildScanPublishing(BuildScanExtension buildScan) {
         /* Example of build scan publishing configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -54,7 +54,7 @@ final class CustomGradleEnterpriseConfig {
         */
     }
 
-    public void configureBuildCache(BuildCacheConfiguration buildCache) {
+    void configureBuildCache(BuildCacheConfiguration buildCache) {
         /* Example of build cache configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -120,7 +120,6 @@ final class CustomGradleEnterpriseConfig {
     private void withSystemProp(String systemPropertyName, Consumer<String> action) {
         Provider<String> prop = providers.systemProperty(systemPropertyName).forUseAtConfigurationTime();
         if(prop.isPresent()) {
-            System.out.println("Using " + systemPropertyName + ": " + prop.get());
             action.accept(prop.get());
         }
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -33,7 +33,8 @@ final class CustomGradleEnterpriseConfig {
         gradleEnterprise.setServer("https://your-gradle-enterprise-server.com");
 
         */
-        withSysProperty(providers, GRADLE_ENTERPRISE_URL_PROP, gradleEnterprise::setServer);
+
+        withSysProperty(GRADLE_ENTERPRISE_URL_PROP, gradleEnterprise::setServer, providers);
     }
 
     static void configureBuildScanPublishing(BuildScanExtension buildScan, ProviderFactory providers) {
@@ -70,24 +71,24 @@ final class CustomGradleEnterpriseConfig {
         */
 
         buildCache.local(local -> {
-            withBooleanSysProperty(providers, LOCAL_CACHE_ENABLED_PROP, local::setEnabled);
-            withSysProperty(providers, LOCAL_CACHE_DIRECTORY_PROP, local::setDirectory);
-            withSysProperty(providers, LOCAL_CACHE_CLEANUP_RETENTION_PROP, value -> {
+            withBooleanSysProperty(LOCAL_CACHE_ENABLED_PROP, local::setEnabled, providers);
+            withSysProperty(LOCAL_CACHE_DIRECTORY_PROP, local::setDirectory, providers);
+            withSysProperty(LOCAL_CACHE_CLEANUP_RETENTION_PROP, value -> {
                 Duration retention = Duration.parse(System.getProperty(LOCAL_CACHE_CLEANUP_RETENTION_PROP));
                 local.setRemoveUnusedEntriesAfterDays((int) retention.toDays());
-            });
-            withBooleanSysProperty(providers, LOCAL_CACHE_CLEANUP_ENABLED_PROP, localCacheCleanupEnabled -> {
+            }, providers);
+            withBooleanSysProperty(LOCAL_CACHE_CLEANUP_ENABLED_PROP, localCacheCleanupEnabled -> {
                 if (!localCacheCleanupEnabled) {
                     local.setRemoveUnusedEntriesAfterDays(Integer.MAX_VALUE);
                 }
-            });
+            }, providers);
         });
 
         buildCache.remote(HttpBuildCache.class, remote -> {
-            withSysProperty(providers, REMOTE_CACHE_URL_PROP, remote::setUrl);
-            withBooleanSysProperty(providers, REMOTE_CACHE_ENABLED_PROP, remote::setEnabled);
-            withBooleanSysProperty(providers, REMOTE_CACHE_PUSH_ENABLED_PROP, remote::setPush);
-            withBooleanSysProperty(providers, REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, remote::setAllowUntrustedServer);
+            withSysProperty(REMOTE_CACHE_URL_PROP, remote::setUrl, providers);
+            withBooleanSysProperty(REMOTE_CACHE_ENABLED_PROP, remote::setEnabled, providers);
+            withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED_PROP, remote::setPush, providers);
+            withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, remote::setAllowUntrustedServer, providers);
         });
     }
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -2,7 +2,6 @@ package com.gradle;
 
 import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
 import com.gradle.scan.plugin.BuildScanExtension;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
@@ -10,8 +9,6 @@ import org.gradle.caching.http.HttpBuildCache;
 import javax.inject.Inject;
 import java.time.Duration;
 import java.util.function.Consumer;
-
-import static java.lang.Boolean.parseBoolean;
 
 /**
  * Provide standardized Gradle Enterprise configuration.

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -75,7 +75,7 @@ final class CustomGradleEnterpriseConfig {
             withBooleanSysProperty(LOCAL_CACHE_ENABLED, local::setEnabled, providers);
             withSysProperty(LOCAL_CACHE_DIRECTORY, local::setDirectory, providers);
             withSysProperty(LOCAL_CACHE_CLEANUP_RETENTION, value -> {
-                Duration retention = Duration.parse(System.getProperty(LOCAL_CACHE_CLEANUP_RETENTION));
+                Duration retention = Duration.parse(value);
                 local.setRemoveUnusedEntriesAfterDays((int) retention.toDays());
             }, providers);
             withBooleanSysProperty(LOCAL_CACHE_CLEANUP_ENABLED, localCacheCleanupEnabled -> {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -4,11 +4,6 @@ import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
 import com.gradle.scan.plugin.BuildScanExtension;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
-import org.gradle.caching.http.HttpBuildCache;
-
-import static com.gradle.Utils.withBooleanSysProperty;
-import static com.gradle.Utils.withDurationSysProperty;
-import static com.gradle.Utils.withSysProperty;
 
 /**
  * Provide standardized Gradle Enterprise configuration.
@@ -16,28 +11,15 @@ import static com.gradle.Utils.withSysProperty;
  */
 final class CustomGradleEnterpriseConfig {
 
-    // system properties to override Gradle Enterprise, Build Cache, and Build Scan configuration
-    public static final String GRADLE_ENTERPRISE_URL = "gradle.enterprise.url";
-    public static final String LOCAL_CACHE_DIRECTORY = "gradle.cache.local.directory";
-    public static final String LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS = "gradle.cache.local.removeUnusedEntriesAfterDays";
-    public static final String LOCAL_CACHE_ENABLED = "gradle.cache.local.enabled";
-    public static final String LOCAL_CACHE_PUSH_ENABLED = "gradle.cache.local.push";
-    public static final String REMOTE_CACHE_URL = "gradle.cache.remote.url";
-    public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
-    public static final String REMOTE_CACHE_ENABLED = "gradle.cache.remote.enabled";
-    public static final String REMOTE_CACHE_PUSH_ENABLED = "gradle.cache.remote.push";
-
-    static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers) {
+    static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise) {
         /* Example of Gradle Enterprise configuration
 
         gradleEnterprise.setServer("https://your-gradle-enterprise-server.com");
 
         */
-
-        withSysProperty(GRADLE_ENTERPRISE_URL, gradleEnterprise::setServer, providers);
     }
 
-    static void configureBuildScanPublishing(BuildScanExtension buildScan, ProviderFactory providers) {
+    static void configureBuildScanPublishing(BuildScanExtension buildScan) {
         /* Example of build scan publishing configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -49,7 +31,7 @@ final class CustomGradleEnterpriseConfig {
         */
     }
 
-    static void configureBuildCache(BuildCacheConfiguration buildCache, ProviderFactory providers) {
+    static void configureBuildCache(BuildCacheConfiguration buildCache) {
         /* Example of build cache configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -69,23 +51,6 @@ final class CustomGradleEnterpriseConfig {
         });
 
         */
-
-        buildCache.local(local -> {
-            withSysProperty(LOCAL_CACHE_DIRECTORY, local::setDirectory, providers);
-            withDurationSysProperty(LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS, v -> local.setRemoveUnusedEntriesAfterDays((int) v.toDays()), providers);
-            withBooleanSysProperty(LOCAL_CACHE_ENABLED, local::setEnabled, providers);
-            withBooleanSysProperty(LOCAL_CACHE_PUSH_ENABLED, local::setPush, providers);
-        });
-
-        // null check required to avoid creating a remote build cache instance when none was already present in the build
-        if (buildCache.getRemote() != null) {
-            buildCache.remote(HttpBuildCache.class, remote -> {
-                withSysProperty(REMOTE_CACHE_URL, remote::setUrl, providers);
-                withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
-                withBooleanSysProperty(REMOTE_CACHE_ENABLED, remote::setEnabled, providers);
-                withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, remote::setPush, providers);
-            });
-        }
     }
 
     private CustomGradleEnterpriseConfig() {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -77,12 +77,15 @@ final class CustomGradleEnterpriseConfig {
             withBooleanSysProperty(LOCAL_CACHE_PUSH_ENABLED, local::setPush, providers);
         });
 
-        buildCache.remote(HttpBuildCache.class, remote -> {
-            withSysProperty(REMOTE_CACHE_URL, remote::setUrl, providers);
-            withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
-            withBooleanSysProperty(REMOTE_CACHE_ENABLED, remote::setEnabled, providers);
-            withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, remote::setPush, providers);
-        });
+        // null check required to avoid creating a remote build cache instance when none was already present in the build
+        if (buildCache.getRemote() != null) {
+            buildCache.remote(HttpBuildCache.class, remote -> {
+                withSysProperty(REMOTE_CACHE_URL, remote::setUrl, providers);
+                withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
+                withBooleanSysProperty(REMOTE_CACHE_ENABLED, remote::setEnabled, providers);
+                withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, remote::setPush, providers);
+            });
+        }
     }
 
     private CustomGradleEnterpriseConfig() {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -24,9 +24,9 @@ final class CustomGradleEnterpriseConfig {
     public static final String LOCAL_CACHE_CLEANUP_ENABLED = "gradle.cache.local.cleanup.enabled";
     public static final String LOCAL_CACHE_CLEANUP_RETENTION = "gradle.cache.local.cleanup.retention";
     public static final String REMOTE_CACHE_URL = "gradle.cache.remote.url";
+    public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
     public static final String REMOTE_CACHE_ENABLED = "gradle.cache.remote.enabled";
     public static final String REMOTE_CACHE_PUSH_ENABLED = "gradle.cache.remote.storeEnabled";
-    public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
 
     static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers) {
         /* Example of Gradle Enterprise configuration
@@ -87,9 +87,9 @@ final class CustomGradleEnterpriseConfig {
 
         buildCache.remote(HttpBuildCache.class, remote -> {
             withSysProperty(REMOTE_CACHE_URL, remote::setUrl, providers);
+            withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
             withBooleanSysProperty(REMOTE_CACHE_ENABLED, remote::setEnabled, providers);
             withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, remote::setPush, providers);
-            withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
         });
     }
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -6,7 +6,6 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
 
-import javax.inject.Inject;
 import java.time.Duration;
 
 import static com.gradle.Utils.withBooleanSysProperty;
@@ -30,7 +29,6 @@ final class CustomGradleEnterpriseConfig {
 
     private final ProviderFactory providers;
 
-    @Inject
     CustomGradleEnterpriseConfig(ProviderFactory providers) {
         this.providers = providers;
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -6,9 +6,8 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
 
-import java.time.Duration;
-
 import static com.gradle.Utils.withBooleanSysProperty;
+import static com.gradle.Utils.withDurationSysProperty;
 import static com.gradle.Utils.withSysProperty;
 
 /**
@@ -19,10 +18,10 @@ final class CustomGradleEnterpriseConfig {
 
     // system properties to override Gradle Enterprise, Build Cache, and Build Scan configuration
     public static final String GRADLE_ENTERPRISE_URL = "gradle.enterprise.url";
-    public static final String LOCAL_CACHE_ENABLED = "gradle.cache.local.enabled";
     public static final String LOCAL_CACHE_DIRECTORY = "gradle.cache.local.directory";
-    public static final String LOCAL_CACHE_CLEANUP_ENABLED = "gradle.cache.local.cleanup.enabled";
-    public static final String LOCAL_CACHE_CLEANUP_RETENTION = "gradle.cache.local.cleanup.retention";
+    public static final String LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS = "gradle.cache.local.removeUnusedEntriesAfterDays";
+    public static final String LOCAL_CACHE_ENABLED = "gradle.cache.local.enabled";
+    public static final String LOCAL_CACHE_PUSH_ENABLED = "gradle.cache.local.push";
     public static final String REMOTE_CACHE_URL = "gradle.cache.remote.url";
     public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
     public static final String REMOTE_CACHE_ENABLED = "gradle.cache.remote.enabled";
@@ -72,17 +71,10 @@ final class CustomGradleEnterpriseConfig {
         */
 
         buildCache.local(local -> {
-            withBooleanSysProperty(LOCAL_CACHE_ENABLED, local::setEnabled, providers);
             withSysProperty(LOCAL_CACHE_DIRECTORY, local::setDirectory, providers);
-            withSysProperty(LOCAL_CACHE_CLEANUP_RETENTION, value -> {
-                Duration retention = Duration.parse(value);
-                local.setRemoveUnusedEntriesAfterDays((int) retention.toDays());
-            }, providers);
-            withBooleanSysProperty(LOCAL_CACHE_CLEANUP_ENABLED, localCacheCleanupEnabled -> {
-                if (!localCacheCleanupEnabled) {
-                    local.setRemoveUnusedEntriesAfterDays(Integer.MAX_VALUE);
-                }
-            }, providers);
+            withDurationSysProperty(LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS, v -> local.setRemoveUnusedEntriesAfterDays((int) v.toDays()), providers);
+            withBooleanSysProperty(LOCAL_CACHE_ENABLED, local::setEnabled, providers);
+            withBooleanSysProperty(LOCAL_CACHE_PUSH_ENABLED, local::setPush, providers);
         });
 
         buildCache.remote(HttpBuildCache.class, remote -> {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -91,18 +91,10 @@ final class CustomGradleEnterpriseConfig {
                 });
         });
 
-        withSysProperty(providers, REMOTE_CACHE_URL_PROP, value -> {
-            buildCache.remote(HttpBuildCache.class).setUrl(value);
-        });
-        withBooleanSysProperty(providers, REMOTE_CACHE_ENABLED_PROP, value -> {
-            buildCache.remote(HttpBuildCache.class).setEnabled(value);
-        });
-        withBooleanSysProperty(providers, REMOTE_CACHE_PUSH_ENABLED_PROP, value -> {
-            buildCache.remote(HttpBuildCache.class).setPush(value);
-        });
-        withBooleanSysProperty(providers, REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, value -> {
-            buildCache.remote(HttpBuildCache.class).setAllowUntrustedServer(value);
-        });
+        withSysProperty(providers, REMOTE_CACHE_URL_PROP, value -> buildCache.remote(HttpBuildCache.class).setUrl(value));
+        withBooleanSysProperty(providers, REMOTE_CACHE_ENABLED_PROP, value -> buildCache.remote(HttpBuildCache.class).setEnabled(value));
+        withBooleanSysProperty(providers, REMOTE_CACHE_PUSH_ENABLED_PROP, value -> buildCache.remote(HttpBuildCache.class).setPush(value));
+        withBooleanSysProperty(providers, REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, value -> buildCache.remote(HttpBuildCache.class).setAllowUntrustedServer(value));
     }
 
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -2,9 +2,11 @@ package com.gradle;
 
 import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
 import com.gradle.scan.plugin.BuildScanExtension;
+import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
 
+import javax.inject.Inject;
 import java.time.Duration;
 
 import static java.lang.Boolean.parseBoolean;
@@ -14,7 +16,6 @@ import static java.lang.Boolean.parseBoolean;
  * By applying the plugin, these settings will automatically be applied.
  */
 final class CustomGradleEnterpriseConfig {
-
     public static final String GRADLE_ENTERPRISE_URL_PROP = "gradle.enterprise.url";
     public static final String CAPTURE_TASK_INPUT_FILES_PROP = "gradle.scan.captureTaskInputFiles";
     public static final String UPLOAD_IN_BACKGROUND_PROP = "gradle.scan.uploadInBackground";
@@ -29,7 +30,14 @@ final class CustomGradleEnterpriseConfig {
     public static final String REMOTE_CACHE_USERNAME_PROP = "gradle.cache.remote.username";
     public static final String REMOTE_CACHE_PASSWORD_PROP = "gradle.cache.remote.password";
 
-    static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise) {
+    private final ProviderFactory providers;
+
+    @Inject
+    CustomGradleEnterpriseConfig(ProviderFactory providers) {
+        this.providers = providers;
+    }
+
+    public void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise) {
         /* Example of Gradle Enterprise configuration
 
         gradleEnterprise.setServer("https://your-gradle-enterprise-server.com");
@@ -40,7 +48,7 @@ final class CustomGradleEnterpriseConfig {
         }
     }
 
-    static void configureBuildScanPublishing(BuildScanExtension buildScan) {
+    public void configureBuildScanPublishing(BuildScanExtension buildScan) {
         /* Example of build scan publishing configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -58,7 +66,7 @@ final class CustomGradleEnterpriseConfig {
         }
     }
 
-    static void configureBuildCache(BuildCacheConfiguration buildCache) {
+    public void configureBuildCache(BuildCacheConfiguration buildCache) {
         /* Example of build cache configuration
 
         boolean isCiServer = System.getenv().containsKey("CI");
@@ -115,8 +123,4 @@ final class CustomGradleEnterpriseConfig {
             buildCache.remote(HttpBuildCache.class).getCredentials().setUsername(System.getProperty(REMOTE_CACHE_PASSWORD_PROP));
         }
     }
-
-    private CustomGradleEnterpriseConfig() {
-    }
-
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -26,7 +26,7 @@ final class CustomGradleEnterpriseConfig {
     public static final String REMOTE_CACHE_URL = "gradle.cache.remote.url";
     public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
     public static final String REMOTE_CACHE_ENABLED = "gradle.cache.remote.enabled";
-    public static final String REMOTE_CACHE_PUSH_ENABLED = "gradle.cache.remote.storeEnabled";
+    public static final String REMOTE_CACHE_PUSH_ENABLED = "gradle.cache.remote.push";
 
     static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers) {
         /* Example of Gradle Enterprise configuration

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -81,20 +81,22 @@ final class CustomGradleEnterpriseConfig {
             withBooleanSysProperty(providers, LOCAL_CACHE_ENABLED_PROP, local::setEnabled);
             withSysProperty(providers, LOCAL_CACHE_DIRECTORY_PROP, local::setDirectory);
             withSysProperty(providers, LOCAL_CACHE_CLEANUP_RETENTION_PROP, value -> {
-                    Duration retention = Duration.parse(System.getProperty(LOCAL_CACHE_CLEANUP_RETENTION_PROP));
-                    local.setRemoveUnusedEntriesAfterDays((int) retention.toDays());
-                });
+                Duration retention = Duration.parse(System.getProperty(LOCAL_CACHE_CLEANUP_RETENTION_PROP));
+                local.setRemoveUnusedEntriesAfterDays((int) retention.toDays());
+            });
             withBooleanSysProperty(providers, LOCAL_CACHE_CLEANUP_ENABLED_PROP, localCacheCleanupEnabled -> {
-                    if (!localCacheCleanupEnabled) {
-                        local.setRemoveUnusedEntriesAfterDays(Integer.MAX_VALUE);
-                    }
-                });
+                if (!localCacheCleanupEnabled) {
+                    local.setRemoveUnusedEntriesAfterDays(Integer.MAX_VALUE);
+                }
+            });
         });
 
-        withSysProperty(providers, REMOTE_CACHE_URL_PROP, value -> buildCache.remote(HttpBuildCache.class).setUrl(value));
-        withBooleanSysProperty(providers, REMOTE_CACHE_ENABLED_PROP, value -> buildCache.remote(HttpBuildCache.class).setEnabled(value));
-        withBooleanSysProperty(providers, REMOTE_CACHE_PUSH_ENABLED_PROP, value -> buildCache.remote(HttpBuildCache.class).setPush(value));
-        withBooleanSysProperty(providers, REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, value -> buildCache.remote(HttpBuildCache.class).setAllowUntrustedServer(value));
+        buildCache.remote(HttpBuildCache.class, remote -> {
+            withSysProperty(providers, REMOTE_CACHE_URL_PROP, remote::setUrl);
+            withBooleanSysProperty(providers, REMOTE_CACHE_ENABLED_PROP, remote::setEnabled);
+            withBooleanSysProperty(providers, REMOTE_CACHE_PUSH_ENABLED_PROP, remote::setPush);
+            withBooleanSysProperty(providers, REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, remote::setAllowUntrustedServer);
+        });
     }
 
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -10,6 +10,9 @@ import javax.inject.Inject;
 import java.time.Duration;
 import java.util.function.Consumer;
 
+import static com.gradle.Utils.withBooleanSysProperty;
+import static com.gradle.Utils.withSysProperty;
+
 /**
  * Provide standardized Gradle Enterprise configuration.
  * By applying the plugin, these settings will automatically be applied.
@@ -104,10 +107,10 @@ final class CustomGradleEnterpriseConfig {
     }
 
     private void withSystemProp(String systemPropertyName, Consumer<String> action) {
-        Utils.withSysProperty(providers, systemPropertyName, action);
+        withSysProperty(providers, systemPropertyName, action);
     }
 
     private void withBooleanSystemProp(String systemPropertyName, Consumer<Boolean> action) {
-        Utils.withBooleanSysProperty(providers, systemPropertyName, action);
+        withBooleanSysProperty(providers, systemPropertyName, action);
     }
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -17,15 +17,16 @@ import static com.gradle.Utils.withSysProperty;
  */
 final class CustomGradleEnterpriseConfig {
 
-    public static final String GRADLE_ENTERPRISE_URL_PROP = "gradle.enterprise.url";
-    public static final String LOCAL_CACHE_ENABLED_PROP = "gradle.cache.local.enabled";
-    public static final String LOCAL_CACHE_DIRECTORY_PROP = "gradle.cache.local.directory";
-    public static final String LOCAL_CACHE_CLEANUP_ENABLED_PROP = "gradle.cache.local.cleanup.enabled";
-    public static final String LOCAL_CACHE_CLEANUP_RETENTION_PROP = "gradle.cache.local.cleanup.retention";
-    public static final String REMOTE_CACHE_URL_PROP = "gradle.cache.remote.url";
-    public static final String REMOTE_CACHE_ENABLED_PROP = "gradle.cache.remote.enabled";
-    public static final String REMOTE_CACHE_PUSH_ENABLED_PROP = "gradle.cache.remote.storeEnabled";
-    public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP = "gradle.cache.remote.allowUntrustedServer";
+    // system properties to override Gradle Enterprise, Build Cache, and Build Scan configuration
+    public static final String GRADLE_ENTERPRISE_URL = "gradle.enterprise.url";
+    public static final String LOCAL_CACHE_ENABLED = "gradle.cache.local.enabled";
+    public static final String LOCAL_CACHE_DIRECTORY = "gradle.cache.local.directory";
+    public static final String LOCAL_CACHE_CLEANUP_ENABLED = "gradle.cache.local.cleanup.enabled";
+    public static final String LOCAL_CACHE_CLEANUP_RETENTION = "gradle.cache.local.cleanup.retention";
+    public static final String REMOTE_CACHE_URL = "gradle.cache.remote.url";
+    public static final String REMOTE_CACHE_ENABLED = "gradle.cache.remote.enabled";
+    public static final String REMOTE_CACHE_PUSH_ENABLED = "gradle.cache.remote.storeEnabled";
+    public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
 
     static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers) {
         /* Example of Gradle Enterprise configuration
@@ -34,7 +35,7 @@ final class CustomGradleEnterpriseConfig {
 
         */
 
-        withSysProperty(GRADLE_ENTERPRISE_URL_PROP, gradleEnterprise::setServer, providers);
+        withSysProperty(GRADLE_ENTERPRISE_URL, gradleEnterprise::setServer, providers);
     }
 
     static void configureBuildScanPublishing(BuildScanExtension buildScan, ProviderFactory providers) {
@@ -71,13 +72,13 @@ final class CustomGradleEnterpriseConfig {
         */
 
         buildCache.local(local -> {
-            withBooleanSysProperty(LOCAL_CACHE_ENABLED_PROP, local::setEnabled, providers);
-            withSysProperty(LOCAL_CACHE_DIRECTORY_PROP, local::setDirectory, providers);
-            withSysProperty(LOCAL_CACHE_CLEANUP_RETENTION_PROP, value -> {
-                Duration retention = Duration.parse(System.getProperty(LOCAL_CACHE_CLEANUP_RETENTION_PROP));
+            withBooleanSysProperty(LOCAL_CACHE_ENABLED, local::setEnabled, providers);
+            withSysProperty(LOCAL_CACHE_DIRECTORY, local::setDirectory, providers);
+            withSysProperty(LOCAL_CACHE_CLEANUP_RETENTION, value -> {
+                Duration retention = Duration.parse(System.getProperty(LOCAL_CACHE_CLEANUP_RETENTION));
                 local.setRemoveUnusedEntriesAfterDays((int) retention.toDays());
             }, providers);
-            withBooleanSysProperty(LOCAL_CACHE_CLEANUP_ENABLED_PROP, localCacheCleanupEnabled -> {
+            withBooleanSysProperty(LOCAL_CACHE_CLEANUP_ENABLED, localCacheCleanupEnabled -> {
                 if (!localCacheCleanupEnabled) {
                     local.setRemoveUnusedEntriesAfterDays(Integer.MAX_VALUE);
                 }
@@ -85,10 +86,10 @@ final class CustomGradleEnterpriseConfig {
         });
 
         buildCache.remote(HttpBuildCache.class, remote -> {
-            withSysProperty(REMOTE_CACHE_URL_PROP, remote::setUrl, providers);
-            withBooleanSysProperty(REMOTE_CACHE_ENABLED_PROP, remote::setEnabled, providers);
-            withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED_PROP, remote::setPush, providers);
-            withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, remote::setAllowUntrustedServer, providers);
+            withSysProperty(REMOTE_CACHE_URL, remote::setUrl, providers);
+            withBooleanSysProperty(REMOTE_CACHE_ENABLED, remote::setEnabled, providers);
+            withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, remote::setPush, providers);
+            withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
         });
     }
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -18,6 +18,7 @@ import static java.lang.Boolean.parseBoolean;
  * By applying the plugin, these settings will automatically be applied.
  */
 final class CustomGradleEnterpriseConfig {
+
     public static final String GRADLE_ENTERPRISE_URL_PROP = "gradle.enterprise.url";
     public static final String LOCAL_CACHE_ENABLED_PROP = "gradle.cache.local.enabled";
     public static final String LOCAL_CACHE_DIRECTORY_PROP = "gradle.cache.local.directory";
@@ -85,7 +86,7 @@ final class CustomGradleEnterpriseConfig {
                 local.setRemoveUnusedEntriesAfterDays((int) retention.toDays());
             });
             withBooleanSystemProp(LOCAL_CACHE_CLEANUP_ENABLED_PROP, localCacheCleanupEnabled -> {
-                if(!localCacheCleanupEnabled) {
+                if (!localCacheCleanupEnabled) {
                     local.setRemoveUnusedEntriesAfterDays(Integer.MAX_VALUE);
                 }
             });
@@ -106,10 +107,10 @@ final class CustomGradleEnterpriseConfig {
     }
 
     private void withSystemProp(String systemPropertyName, Consumer<String> action) {
-        Utils.withSystemProp(providers, systemPropertyName, action);
+        Utils.withSysProperty(providers, systemPropertyName, action);
     }
 
     private void withBooleanSystemProp(String systemPropertyName, Consumer<Boolean> action) {
-        Utils.withBooleanSystemProp(providers, systemPropertyName, action);
+        Utils.withBooleanSysProperty(providers, systemPropertyName, action);
     }
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -19,8 +19,6 @@ import static java.lang.Boolean.parseBoolean;
  */
 final class CustomGradleEnterpriseConfig {
     public static final String GRADLE_ENTERPRISE_URL_PROP = "gradle.enterprise.url";
-    public static final String CAPTURE_TASK_INPUT_FILES_PROP = "gradle.scan.captureTaskInputFiles";
-    public static final String UPLOAD_IN_BACKGROUND_PROP = "gradle.scan.uploadInBackground";
     public static final String LOCAL_CACHE_ENABLED_PROP = "gradle.cache.local.enabled";
     public static final String LOCAL_CACHE_DIRECTORY_PROP = "gradle.cache.local.directory";
     public static final String LOCAL_CACHE_CLEANUP_ENABLED_PROP = "gradle.cache.local.cleanup.enabled";
@@ -29,8 +27,6 @@ final class CustomGradleEnterpriseConfig {
     public static final String REMOTE_CACHE_ENABLED_PROP = "gradle.cache.remote.enabled";
     public static final String REMOTE_CACHE_PUSH_ENABLED_PROP = "gradle.cache.remote.storeEnabled";
     public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP = "gradle.cache.remote.allowUntrustedServer";
-    public static final String REMOTE_CACHE_USERNAME_PROP = "gradle.cache.remote.username";
-    public static final String REMOTE_CACHE_PASSWORD_PROP = "gradle.cache.remote.password";
 
     private final ProviderFactory providers;
 
@@ -58,8 +54,6 @@ final class CustomGradleEnterpriseConfig {
         buildScan.setUploadInBackground(!isCiServer);
 
         */
-        withBooleanSystemProp(CAPTURE_TASK_INPUT_FILES_PROP, buildScan::setCaptureTaskInputFiles);
-        withBooleanSystemProp(UPLOAD_IN_BACKGROUND_PROP, buildScan::setUploadInBackground);
     }
 
     public void configureBuildCache(BuildCacheConfiguration buildCache) {
@@ -108,12 +102,6 @@ final class CustomGradleEnterpriseConfig {
         });
         withBooleanSystemProp(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER_PROP, value -> {
             buildCache.remote(HttpBuildCache.class).setAllowUntrustedServer(value);
-        });
-        withSystemProp(REMOTE_CACHE_USERNAME_PROP, value -> {
-            buildCache.remote(HttpBuildCache.class).getCredentials().setUsername(value);
-        });
-        withSystemProp(REMOTE_CACHE_PASSWORD_PROP, value -> {
-            buildCache.remote(HttpBuildCache.class).getCredentials().setUsername(value);
         });
     }
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
@@ -1,0 +1,54 @@
+package com.gradle;
+
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.caching.configuration.BuildCacheConfiguration;
+import org.gradle.caching.http.HttpBuildCache;
+
+import static com.gradle.Utils.withBooleanSysProperty;
+import static com.gradle.Utils.withDurationSysProperty;
+import static com.gradle.Utils.withSysProperty;
+
+/**
+ * Provide standardized Gradle Enterprise configuration.
+ * By applying the plugin, these settings will automatically be applied.
+ */
+final class SystemPropertyOverrides {
+
+    // system properties to override Gradle Enterprise, Build Cache, and Build Scan configuration
+    public static final String GRADLE_ENTERPRISE_URL = "gradle.enterprise.url";
+    public static final String LOCAL_CACHE_DIRECTORY = "gradle.cache.local.directory";
+    public static final String LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS = "gradle.cache.local.removeUnusedEntriesAfterDays";
+    public static final String LOCAL_CACHE_ENABLED = "gradle.cache.local.enabled";
+    public static final String LOCAL_CACHE_PUSH_ENABLED = "gradle.cache.local.push";
+    public static final String REMOTE_CACHE_URL = "gradle.cache.remote.url";
+    public static final String REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER = "gradle.cache.remote.allowUntrustedServer";
+    public static final String REMOTE_CACHE_ENABLED = "gradle.cache.remote.enabled";
+    public static final String REMOTE_CACHE_PUSH_ENABLED = "gradle.cache.remote.push";
+
+    static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers) {
+        withSysProperty(GRADLE_ENTERPRISE_URL, gradleEnterprise::setServer, providers);
+    }
+
+    static void configureBuildCache(BuildCacheConfiguration buildCache, ProviderFactory providers) {
+        buildCache.local(local -> {
+            withSysProperty(LOCAL_CACHE_DIRECTORY, local::setDirectory, providers);
+            withDurationSysProperty(LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS, v -> local.setRemoveUnusedEntriesAfterDays((int) v.toDays()), providers);
+            withBooleanSysProperty(LOCAL_CACHE_ENABLED, local::setEnabled, providers);
+            withBooleanSysProperty(LOCAL_CACHE_PUSH_ENABLED, local::setPush, providers);
+        });
+
+        // null check required to avoid creating a remote build cache instance when none was already present in the build
+        if (buildCache.getRemote() != null) {
+            buildCache.remote(HttpBuildCache.class, remote -> {
+                withSysProperty(REMOTE_CACHE_URL, remote::setUrl, providers);
+                withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
+                withBooleanSysProperty(REMOTE_CACHE_ENABLED, remote::setEnabled, providers);
+                withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, remote::setPush, providers);
+            });
+        }
+    }
+
+    private SystemPropertyOverrides() {
+    }
+}

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -43,9 +43,18 @@ final class Utils {
     }
 
     static void withSystemProp(ProviderFactory providers, String systemPropertyName, Consumer<String> action) {
-        Provider<String> prop = providers.systemProperty(systemPropertyName).forUseAtConfigurationTime();
-        if(prop.isPresent()) {
-            action.accept(prop.get());
+        try {
+            Provider<String> prop = providers.systemProperty(systemPropertyName).forUseAtConfigurationTime();
+            if (prop.isPresent()) {
+                action.accept(prop.get());
+            }
+        } catch (NoSuchMethodError e) {
+            // If we get here, we're running on an earlier version of Gradle that doesn't support providers.systemProperty
+            // Fallback to direct system property access
+            Optional<String> prop = sysProperty(systemPropertyName);
+            if(prop.isPresent()) {
+                action.accept(prop.get());
+            }
         }
     }
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -43,7 +43,7 @@ final class Utils {
         return false;
     }
 
-    static void withSysProperty(ProviderFactory providers, String name, Consumer<String> action) {
+    static void withSysProperty(String name, Consumer<String> action, ProviderFactory providers) {
         if (isGradle65OrNewer()) {
             Provider<String> property = providers.systemProperty(name).forUseAtConfigurationTime();
             if (property.isPresent()) {
@@ -55,8 +55,8 @@ final class Utils {
         }
     }
 
-    static void withBooleanSysProperty(ProviderFactory providers, String name, Consumer<Boolean> action) {
-        withSysProperty(providers, name, value -> action.accept(parseBoolean(value)));
+    static void withBooleanSysProperty(String name, Consumer<Boolean> action, ProviderFactory providers) {
+        withSysProperty(name, value -> action.accept(parseBoolean(value)), providers);
     }
 
     static Optional<String> envVariable(String name) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -43,7 +43,7 @@ final class Utils {
         return false;
     }
 
-    static void withSystemProp(ProviderFactory providers, String name, Consumer<String> action) {
+    static void withSysProperty(ProviderFactory providers, String name, Consumer<String> action) {
         if (isGradle65OrNewer()) {
             Provider<String> property = providers.systemProperty(name).forUseAtConfigurationTime();
             if (property.isPresent()) {
@@ -55,8 +55,8 @@ final class Utils {
         }
     }
 
-    static void withBooleanSystemProp(ProviderFactory providers, String systemPropertyName, Consumer<Boolean> action) {
-        withSystemProp(providers, systemPropertyName, value -> {
+    static void withBooleanSysProperty(ProviderFactory providers, String systemPropertyName, Consumer<Boolean> action) {
+        withSysProperty(providers, systemPropertyName, value -> {
             action.accept(parseBoolean(value));
         });
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -55,8 +55,8 @@ final class Utils {
         }
     }
 
-    static void withBooleanSysProperty(ProviderFactory providers, String systemPropertyName, Consumer<Boolean> action) {
-        withSysProperty(providers, systemPropertyName, value -> action.accept(parseBoolean(value)));
+    static void withBooleanSysProperty(ProviderFactory providers, String name, Consumer<Boolean> action) {
+        withSysProperty(providers, name, value -> action.accept(parseBoolean(value)));
     }
 
     static Optional<String> envVariable(String name) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -56,9 +56,7 @@ final class Utils {
     }
 
     static void withBooleanSysProperty(ProviderFactory providers, String systemPropertyName, Consumer<Boolean> action) {
-        withSysProperty(providers, systemPropertyName, value -> {
-            action.accept(parseBoolean(value));
-        });
+        withSysProperty(providers, systemPropertyName, value -> action.accept(parseBoolean(value)));
     }
 
     static Optional<String> envVariable(String name) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -1,5 +1,8 @@
 package com.gradle;
 
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderFactory;
+
 import java.io.BufferedReader;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -13,6 +16,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static java.lang.Boolean.parseBoolean;
 
 final class Utils {
 
@@ -34,6 +40,19 @@ final class Utils {
             }
         }
         return false;
+    }
+
+    static void withSystemProp(ProviderFactory providers, String systemPropertyName, Consumer<String> action) {
+        Provider<String> prop = providers.systemProperty(systemPropertyName).forUseAtConfigurationTime();
+        if(prop.isPresent()) {
+            action.accept(prop.get());
+        }
+    }
+
+    static void withBooleanSystemProp(ProviderFactory providers, String systemPropertyName, Consumer<Boolean> action) {
+        withSystemProp(providers, systemPropertyName, value -> {
+            action.accept(parseBoolean(value));
+        });
     }
 
     static Optional<String> envVariable(String name) {
@@ -122,5 +141,4 @@ final class Utils {
 
     private Utils() {
     }
-
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -14,6 +14,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -57,6 +58,10 @@ final class Utils {
 
     static void withBooleanSysProperty(String name, Consumer<Boolean> action, ProviderFactory providers) {
         withSysProperty(name, value -> action.accept(parseBoolean(value)), providers);
+    }
+
+    static void withDurationSysProperty(String name, Consumer<Duration> action, ProviderFactory providers) {
+        withSysProperty(name, value -> action.accept(Duration.parse(value)), providers);
     }
 
     static Optional<String> envVariable(String name) {


### PR DESCRIPTION
The Gradle Enterprise Maven extension allows users to configure most Gradle
Enterprise configuration settings via Java system properties. This is really
nice when it comes time to run build experiments (particularly during a Gradle
Enterprise trial) because it makes it easy to change settings when running
builds on CI servers (it often avoids the need to make code changes that need
to be pushed to the git repo).

For example, it is possible to disable to local cache but enable the remote
cache through system properties when doing Maven Trial Experiment Number 3. The
user can configure _just_ their CI configuration to make this change and they
don't have to actually edit their Gradle Enterprise configuration files.

Unfortunately, the Gradle Build Tool and Gradle Enterprise Gradle Plugin only
support configuring a small number of settings via System properties.

To afford the same convenience to Gradle users, this PR updates the Common
Custom User Data Gradle plugin to honor the same (or similar) system properties
honored by the Gradle Enterprise Maven extension.

The same property names are used to make it easy for a user familiar with the
Maven extension to also configure a Gradle build (and vice versa).