### PR TITLE
Declare all environment variable and Gradle property access to support the configuration cache

### DIFF
--- a/common-custom-user-data-gradle-plugin/build.gradle
+++ b/common-custom-user-data-gradle-plugin/build.gradle
@@ -49,9 +49,10 @@ pluginBundle {
 
 signing {
     // Require publications to be signed on CI. Otherwise, publication will be signed only if keys are provided.
-    required System.getenv().containsKey("CI")
+    required providers.environmentVariable("CI").forUseAtConfigurationTime().isPresent()
 
-    useInMemoryPgpKeys(System.getenv("PGP_SIGNING_KEY"), System.getenv("PGP_SIGNING_KEY_PASSPHRASE"))
+    useInMemoryPgpKeys(providers.environmentVariable("PGP_SINGING_KEY").forUseAtConfigurationTime().orNull,
+        providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").forUseAtConfigurationTime().orNull)
 
     sign(configurations.archives)
 }

--- a/common-custom-user-data-gradle-plugin/build.gradle
+++ b/common-custom-user-data-gradle-plugin/build.gradle
@@ -39,7 +39,7 @@ When using this project as a template for your own plugin to publish internally,
 You may also remove `plugin-publish`, `signing` and `grgit` from the `plugins {}` block above.
  */
 
-version = System.getenv("RELEASE_OVERRIDE_VERSION") ?: version
+version = providers.environmentVariable("RELEASE_OVERRIDE_VERSION").forUseAtConfigurationTime().getOrElse(version)
 
 pluginBundle {
     website = "https://github.com/gradle/gradle-enterprise-build-config-samples/tree/master/common-custom-user-data-gradle-plugin"

--- a/common-custom-user-data-gradle-plugin/build.gradle
+++ b/common-custom-user-data-gradle-plugin/build.gradle
@@ -51,7 +51,8 @@ signing {
     // Require publications to be signed on CI. Otherwise, publication will be signed only if keys are provided.
     required providers.environmentVariable("CI").forUseAtConfigurationTime().isPresent()
 
-    useInMemoryPgpKeys(providers.environmentVariable("PGP_SINGING_KEY").forUseAtConfigurationTime().orNull,
+    useInMemoryPgpKeys(
+        providers.environmentVariable("PGP_SINGING_KEY").forUseAtConfigurationTime().orNull,
         providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").forUseAtConfigurationTime().orNull)
 
     sign(configurations.archives)

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -42,7 +42,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            CustomBuildScanEnhancements.configureBuildScan(buildScan, settings.getGradle(), providers);
+            CustomBuildScanEnhancements.configureBuildScan(buildScan, providers, settings.getGradle());
 
             BuildCacheConfiguration buildCache = settings.getBuildCache();
             CustomGradleEnterpriseConfig.configureBuildCache(buildCache);
@@ -65,7 +65,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            CustomBuildScanEnhancements.configureBuildScan(buildScan, project.getGradle(), providers);
+            CustomBuildScanEnhancements.configureBuildScan(buildScan, providers, project.getGradle());
 
             // Build cache configuration cannot be accessed from a project plugin
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -42,7 +42,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            CustomBuildScanEnhancements.configureBuildScan(buildScan, settings.getGradle());
+            CustomBuildScanEnhancements.configureBuildScan(buildScan, settings.getGradle(), providers);
 
             BuildCacheConfiguration buildCache = settings.getBuildCache();
             CustomGradleEnterpriseConfig.configureBuildCache(buildCache);
@@ -65,7 +65,7 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             CustomGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            CustomBuildScanEnhancements.configureBuildScan(buildScan, project.getGradle());
+            CustomBuildScanEnhancements.configureBuildScan(buildScan, project.getGradle(), providers);
 
             // Build cache configuration cannot be accessed from a project plugin
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -42,19 +42,21 @@ final class CustomBuildScanEnhancements {
     }
 
     private static void captureIde(BuildScanExtension buildScan, ProviderFactory providers, Gradle gradle) {
-        // Wait for projects to load to ensure Gradle project properties are initialized
-        gradle.projectsEvaluated(g -> {
-            if (projectProperty("android.injected.invoked.from.ide", providers, gradle).isPresent()) {
-                buildScan.tag("Android Studio");
-                projectProperty("android.injected.studio.version", providers, gradle).ifPresent(v -> buildScan.value("Android Studio version", v));
-            } else if (sysProperty("idea.version", providers).isPresent() || sysPropertyKeyStartingWith("idea.version")) {
-                buildScan.tag("IntelliJ IDEA");
-            } else if (sysProperty("eclipse.buildId", providers).isPresent()) {
-                buildScan.tag("Eclipse");
-            } else if (!isCi(providers)) {
-                buildScan.tag("Cmd Line");
-            }
-        });
+        if (!isCi(providers)) {
+            // Wait for projects to load to ensure Gradle project properties are initialized
+            gradle.projectsEvaluated(g -> {
+                if (projectProperty("android.injected.invoked.from.ide", providers, gradle).isPresent()) {
+                    buildScan.tag("Android Studio");
+                    projectProperty("android.injected.studio.version", providers, gradle).ifPresent(v -> buildScan.value("Android Studio version", v));
+                } else if (sysProperty("idea.version", providers).isPresent() || sysPropertyKeyStartingWith("idea.version")) {
+                    buildScan.tag("IntelliJ IDEA");
+                } else if (sysProperty("eclipse.buildId", providers).isPresent()) {
+                    buildScan.tag("Eclipse");
+                } else {
+                    buildScan.tag("Cmd Line");
+                }
+            });
+        }
     }
 
     private static void captureCiOrLocal(BuildScanExtension buildScan, ProviderFactory providers) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -49,8 +49,10 @@ final class CustomBuildScanEnhancements {
                     projectProperty("android.injected.studio.version", providers, gradle).ifPresent(v -> buildScan.value("Android Studio version", v));
                 } else if (sysProperty("idea.version", providers).isPresent()) {
                     buildScan.tag("IntelliJ IDEA");
+                    buildScan.value("IntelliJ IDEA version", sysProperty("idea.version", providers).get());
                 } else if (sysProperty("eclipse.buildId", providers).isPresent()) {
                     buildScan.tag("Eclipse");
+                    buildScan.value("Eclipse version", sysProperty("eclipse.buildId", providers).get());
                 } else {
                     buildScan.tag("Cmd Line");
                 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -84,7 +84,7 @@ final class CustomBuildScanEnhancements {
                 if (teamCityConfigFile.isPresent()
                     && buildNumber.isPresent()
                     && buildTypeId.isPresent()) {
-                    Properties properties = readPropertiesFile(teamCityConfigFile.get());
+                    Properties properties = readPropertiesFile(teamCityConfigFile.get(), providers, gradle);
                     String teamCityServerUrl = properties.getProperty("teamcity.serverUrl");
                     if (teamCityServerUrl != null) {
                         String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildNumber=" + buildNumber.get() + "&buildTypeId=" + buildTypeId.get();

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -20,7 +20,6 @@ import static com.gradle.Utils.isNotEmpty;
 import static com.gradle.Utils.projectProperty;
 import static com.gradle.Utils.readPropertiesFile;
 import static com.gradle.Utils.sysProperty;
-import static com.gradle.Utils.sysPropertyKeyStartingWith;
 import static com.gradle.Utils.urlEncode;
 
 /**
@@ -48,7 +47,7 @@ final class CustomBuildScanEnhancements {
                 if (projectProperty("android.injected.invoked.from.ide", providers, gradle).isPresent()) {
                     buildScan.tag("Android Studio");
                     projectProperty("android.injected.studio.version", providers, gradle).ifPresent(v -> buildScan.value("Android Studio version", v));
-                } else if (sysProperty("idea.version", providers).isPresent() || sysPropertyKeyStartingWith("idea.version")) {
+                } else if (sysProperty("idea.version", providers).isPresent()) {
                     buildScan.tag("IntelliJ IDEA");
                 } else if (sysProperty("eclipse.buildId", providers).isPresent()) {
                     buildScan.tag("Eclipse");

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -28,11 +28,11 @@ import static com.gradle.Utils.urlEncode;
  */
 final class CustomBuildScanEnhancements {
 
-    static void configureBuildScan(BuildScanExtension buildScan, Gradle gradle, ProviderFactory providers) {
+    static void configureBuildScan(BuildScanExtension buildScan, ProviderFactory providers, Gradle gradle) {
         captureOs(buildScan, providers);
-        captureIde(buildScan, gradle, providers);
+        captureIde(buildScan, providers, gradle);
         captureCiOrLocal(buildScan, providers);
-        captureCiMetadata(buildScan, gradle, providers);
+        captureCiMetadata(buildScan, providers, gradle);
         captureGitMetadata(buildScan);
         captureTestParallelization(buildScan, gradle);
     }
@@ -41,7 +41,7 @@ final class CustomBuildScanEnhancements {
         sysProperty("os.name", providers).ifPresent(buildScan::tag);
     }
 
-    private static void captureIde(BuildScanExtension buildScan, Gradle gradle, ProviderFactory providers) {
+    private static void captureIde(BuildScanExtension buildScan, ProviderFactory providers, Gradle gradle) {
         // Wait for projects to load to ensure Gradle project properties are initialized
         gradle.projectsEvaluated(g -> {
             if (projectProperty(gradle, "android.injected.invoked.from.ide", providers).isPresent()) {
@@ -61,7 +61,7 @@ final class CustomBuildScanEnhancements {
         buildScan.tag(isCi(providers) ? "CI" : "LOCAL");
     }
 
-    private static void captureCiMetadata(BuildScanExtension buildScan, Gradle gradle, ProviderFactory providers) {
+    private static void captureCiMetadata(BuildScanExtension buildScan, ProviderFactory providers, Gradle gradle) {
         if (isJenkins(providers) || isHudson(providers)) {
             envVariable("BUILD_URL", providers).ifPresent(url ->
                 buildScan.link(isJenkins(providers) ? "Jenkins build" : "Hudson build", url));

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -2,7 +2,6 @@ package com.gradle;
 
 import com.gradle.scan.plugin.BuildScanExtension;
 import org.gradle.api.Action;
-import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.ProviderFactory;
@@ -45,7 +44,7 @@ final class CustomBuildScanEnhancements {
     private static void captureIde(BuildScanExtension buildScan, Gradle gradle, ProviderFactory providers) {
         // Wait for projects to load to ensure Gradle project properties are initialized
         gradle.projectsEvaluated(g -> {
-            if (projectProperty(gradle,"android.injected.invoked.from.ide", providers).isPresent()) {
+            if (projectProperty(gradle, "android.injected.invoked.from.ide", providers).isPresent()) {
                 buildScan.tag("Android Studio");
                 projectProperty(gradle, "android.injected.studio.version", providers).ifPresent(v -> buildScan.value("Android Studio version", v));
             } else if (sysProperty("idea.version", providers).isPresent() || sysPropertyKeyStartingWith("idea.version")) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -45,12 +45,9 @@ final class CustomBuildScanEnhancements {
     private static void captureIde(BuildScanExtension buildScan, Gradle gradle, ProviderFactory providers) {
         // Wait for projects to load to ensure Gradle project properties are initialized
         gradle.projectsEvaluated(g -> {
-            Project project = g.getRootProject();
-            if (project.hasProperty("android.injected.invoked.from.ide")) {
+            if (projectProperty(gradle,"android.injected.invoked.from.ide", providers).isPresent()) {
                 buildScan.tag("Android Studio");
-                if (project.hasProperty("android.injected.studio.version")) {
-                    buildScan.value("Android Studio version", String.valueOf(project.property("android.injected.studio.version")));
-                }
+                projectProperty(gradle, "android.injected.studio.version", providers).ifPresent(v -> buildScan.value("Android Studio version", v));
             } else if (sysProperty("idea.version", providers).isPresent() || sysPropertyKeyStartingWith("idea.version")) {
                 buildScan.tag("IntelliJ IDEA");
             } else if (sysProperty("eclipse.buildId", providers).isPresent()) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -44,9 +44,9 @@ final class CustomBuildScanEnhancements {
     private static void captureIde(BuildScanExtension buildScan, ProviderFactory providers, Gradle gradle) {
         // Wait for projects to load to ensure Gradle project properties are initialized
         gradle.projectsEvaluated(g -> {
-            if (projectProperty(gradle, "android.injected.invoked.from.ide", providers).isPresent()) {
+            if (projectProperty("android.injected.invoked.from.ide", providers, gradle).isPresent()) {
                 buildScan.tag("Android Studio");
-                projectProperty(gradle, "android.injected.studio.version", providers).ifPresent(v -> buildScan.value("Android Studio version", v));
+                projectProperty("android.injected.studio.version", providers, gradle).ifPresent(v -> buildScan.value("Android Studio version", v));
             } else if (sysProperty("idea.version", providers).isPresent() || sysPropertyKeyStartingWith("idea.version")) {
                 buildScan.tag("IntelliJ IDEA");
             } else if (sysProperty("eclipse.buildId", providers).isPresent()) {
@@ -78,9 +78,9 @@ final class CustomBuildScanEnhancements {
         if (isTeamCity(providers)) {
             // Wait for projects to load to ensure Gradle project properties are initialized
             gradle.projectsEvaluated(g -> {
-                Optional<String> teamCityConfigFile = projectProperty(gradle, "teamcity.configuration.properties.file", providers);
-                Optional<String> buildNumber = projectProperty(gradle, "build.number", providers);
-                Optional<String> buildTypeId = projectProperty(gradle, "teamcity.buildType.id", providers);
+                Optional<String> teamCityConfigFile = projectProperty("teamcity.configuration.properties.file", providers, gradle);
+                Optional<String> buildNumber = projectProperty("build.number", providers, gradle);
+                Optional<String> buildTypeId = projectProperty("teamcity.buildType.id", providers, gradle);
                 if (teamCityConfigFile.isPresent()
                     && buildNumber.isPresent()
                     && buildTypeId.isPresent()) {
@@ -95,7 +95,7 @@ final class CustomBuildScanEnhancements {
                     buildScan.value("CI build number", value));
                 buildTypeId.ifPresent(value ->
                     addCustomValueAndSearchLink(buildScan, "CI build config", value));
-                projectProperty(gradle, "agent.name", providers).ifPresent(value ->
+                projectProperty("agent.name", providers, gradle).ifPresent(value ->
                     addCustomValueAndSearchLink(buildScan, "CI agent", value));
             });
         }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomGradleEnterpriseConfig.java
@@ -2,7 +2,6 @@ package com.gradle;
 
 import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension;
 import com.gradle.scan.plugin.BuildScanExtension;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 
 /**

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
@@ -5,9 +5,9 @@ import org.gradle.api.provider.ProviderFactory;
 import org.gradle.caching.configuration.BuildCacheConfiguration;
 import org.gradle.caching.http.HttpBuildCache;
 
-import static com.gradle.Utils.withBooleanSysProperty;
-import static com.gradle.Utils.withDurationSysProperty;
-import static com.gradle.Utils.withSysProperty;
+import static com.gradle.Utils.booleanSysProperty;
+import static com.gradle.Utils.durationSysProperty;
+import static com.gradle.Utils.sysProperty;
 
 /**
  * Provide standardized Gradle Enterprise configuration.
@@ -27,24 +27,24 @@ final class SystemPropertyOverrides {
     public static final String REMOTE_CACHE_PUSH_ENABLED = "gradle.cache.remote.push";
 
     static void configureGradleEnterprise(GradleEnterpriseExtension gradleEnterprise, ProviderFactory providers) {
-        withSysProperty(GRADLE_ENTERPRISE_URL, gradleEnterprise::setServer, providers);
+        sysProperty(GRADLE_ENTERPRISE_URL, providers).ifPresent(gradleEnterprise::setServer);
     }
 
     static void configureBuildCache(BuildCacheConfiguration buildCache, ProviderFactory providers) {
         buildCache.local(local -> {
-            withSysProperty(LOCAL_CACHE_DIRECTORY, local::setDirectory, providers);
-            withDurationSysProperty(LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS, v -> local.setRemoveUnusedEntriesAfterDays((int) v.toDays()), providers);
-            withBooleanSysProperty(LOCAL_CACHE_ENABLED, local::setEnabled, providers);
-            withBooleanSysProperty(LOCAL_CACHE_PUSH_ENABLED, local::setPush, providers);
+            sysProperty(LOCAL_CACHE_DIRECTORY, providers).ifPresent(local::setDirectory);
+            durationSysProperty(LOCAL_CACHE_REMOVE_UNUSED_ENTRIES_AFTER_DAYS, providers).ifPresent(v -> local.setRemoveUnusedEntriesAfterDays((int) v.toDays()));
+            booleanSysProperty(LOCAL_CACHE_ENABLED, providers).ifPresent(local::setEnabled);
+            booleanSysProperty(LOCAL_CACHE_PUSH_ENABLED, providers).ifPresent(local::setPush);
         });
 
         // null check required to avoid creating a remote build cache instance when none was already present in the build
         if (buildCache.getRemote() != null) {
             buildCache.remote(HttpBuildCache.class, remote -> {
-                withSysProperty(REMOTE_CACHE_URL, remote::setUrl, providers);
-                withBooleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, remote::setAllowUntrustedServer, providers);
-                withBooleanSysProperty(REMOTE_CACHE_ENABLED, remote::setEnabled, providers);
-                withBooleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, remote::setPush, providers);
+                sysProperty(REMOTE_CACHE_URL, providers).ifPresent(remote::setUrl);
+                booleanSysProperty(REMOTE_CACHE_ALLOW_UNTRUSTED_SERVER, providers).ifPresent(remote::setAllowUntrustedServer);
+                booleanSysProperty(REMOTE_CACHE_ENABLED, providers).ifPresent(remote::setEnabled);
+                booleanSysProperty(REMOTE_CACHE_PUSH_ENABLED, providers).ifPresent(remote::setPush);
             });
         }
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -56,8 +56,8 @@ final class Utils {
 
     static Optional<String> envVariable(String name, ProviderFactory providers) {
         if (isGradle65OrNewer()) {
-            Provider<String> property = providers.environmentVariable(name).forUseAtConfigurationTime();
-            return Optional.ofNullable(property.getOrNull());
+            Provider<String> variable = providers.environmentVariable(name).forUseAtConfigurationTime();
+            return Optional.ofNullable(variable.getOrNull());
         }
         return Optional.ofNullable(System.getenv(name));
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -49,16 +49,12 @@ final class Utils {
         return false;
     }
 
-    static void withSysProperty(String name, Consumer<String> action, ProviderFactory providers) {
-        sysProperty(name, providers).ifPresent(action);
+    static Optional<Boolean> booleanSysProperty(String name, ProviderFactory providers) {
+        return sysProperty(name, providers).map(Boolean::parseBoolean);
     }
 
-    static void withBooleanSysProperty(String name, Consumer<Boolean> action, ProviderFactory providers) {
-        withSysProperty(name, value -> action.accept(parseBoolean(value)), providers);
-    }
-
-    static void withDurationSysProperty(String name, Consumer<Duration> action, ProviderFactory providers) {
-        withSysProperty(name, value -> action.accept(Duration.parse(value)), providers);
+    static Optional<Duration> durationSysProperty(String name, ProviderFactory providers) {
+        return sysProperty(name, providers).map(Duration::parse);
     }
 
     static Optional<String> envVariable(String name, ProviderFactory providers) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -28,7 +28,11 @@ final class Utils {
         return value != null && !value.isEmpty();
     }
 
-    static Optional<String> sysProperty(String name) {
+    static Optional<String> sysProperty(String name, ProviderFactory providers) {
+        if (isGradle65OrNewer()) {
+            Provider<String> property = providers.systemProperty(name).forUseAtConfigurationTime();
+            return Optional.ofNullable(property.getOrNull());
+        }
         return Optional.ofNullable(System.getProperty(name));
     }
 
@@ -45,15 +49,7 @@ final class Utils {
     }
 
     static void withSysProperty(String name, Consumer<String> action, ProviderFactory providers) {
-        if (isGradle65OrNewer()) {
-            Provider<String> property = providers.systemProperty(name).forUseAtConfigurationTime();
-            if (property.isPresent()) {
-                action.accept(property.get());
-            }
-        } else {
-            Optional<String> property = sysProperty(name);
-            property.ifPresent(action);
-        }
+        sysProperty(name, providers).ifPresent(action);
     }
 
     static void withBooleanSysProperty(String name, Consumer<Boolean> action, ProviderFactory providers) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -1,5 +1,6 @@
 package com.gradle;
 
+import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.util.GradleVersion;
@@ -66,6 +67,15 @@ final class Utils {
             return Optional.ofNullable(property.getOrNull());
         }
         return Optional.ofNullable(System.getenv(name));
+    }
+
+    static Optional<String> projectProperty(Gradle gradle, String name, ProviderFactory providers) {
+        if (isGradle65OrNewer()) {
+            Provider<String> property = providers.gradleProperty(name).forUseAtConfigurationTime();
+            return Optional.ofNullable(property.getOrNull());
+        }
+        String value = (String) gradle.getRootProject().findProperty(name);
+        return Optional.ofNullable(value);
     }
 
     static String appendIfMissing(String str, String suffix) {
@@ -150,5 +160,4 @@ final class Utils {
 
     private Utils() {
     }
-
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -86,9 +86,8 @@ final class Utils {
 
     static InputStream readFile(String name, ProviderFactory providers, Gradle gradle) throws FileNotFoundException {
         if(isGradle65OrNewer()) {
-            Provider<File> file = providers.provider(() -> new File(name));
-            Provider<RegularFile> regularFile = gradle.getRootProject().getLayout().file(file);
-            Provider<byte[]> fileContent = providers.fileContents(regularFile).getAsBytes().forUseAtConfigurationTime();
+            RegularFile file = gradle.getRootProject().getLayout().getProjectDirectory().file(name);
+            Provider<byte[]> fileContent = providers.fileContents(file).getAsBytes().forUseAtConfigurationTime();
 
             return new ByteArrayInputStream(fileContent.getOrElse(new byte[0]));
         }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -60,12 +60,12 @@ final class Utils {
         withSysProperty(name, value -> action.accept(Duration.parse(value)), providers);
     }
 
-    static Optional<String> envVariable(String name) {
-        String value = System.getenv(name);
-        if (isNotEmpty(value)) {
-            return Optional.of(value);
+    static Optional<String> envVariable(String name, ProviderFactory providers) {
+        if (isGradle65OrNewer()) {
+            Provider<String> property = providers.environmentVariable(name).forUseAtConfigurationTime();
+            return Optional.ofNullable(property.getOrNull());
         }
-        return Optional.empty();
+        return Optional.ofNullable(System.getenv(name));
     }
 
     static String appendIfMissing(String str, String suffix) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -62,7 +62,7 @@ final class Utils {
         return Optional.ofNullable(System.getenv(name));
     }
 
-    static Optional<String> projectProperty(Gradle gradle, String name, ProviderFactory providers) {
+    static Optional<String> projectProperty(String name, ProviderFactory providers, Gradle gradle) {
         if (isGradle65OrNewer()) {
             Provider<String> property = providers.gradleProperty(name).forUseAtConfigurationTime();
             return Optional.ofNullable(property.getOrNull());

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -67,8 +67,7 @@ final class Utils {
             Provider<String> property = providers.gradleProperty(name).forUseAtConfigurationTime();
             return Optional.ofNullable(property.getOrNull());
         }
-        String value = (String) gradle.getRootProject().findProperty(name);
-        return Optional.ofNullable(value);
+        return Optional.ofNullable((String) gradle.getRootProject().findProperty(name));
     }
 
     static String appendIfMissing(String str, String suffix) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -19,9 +19,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
-
-import static java.lang.Boolean.parseBoolean;
 
 final class Utils {
 

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -38,18 +38,6 @@ final class Utils {
         return Optional.ofNullable(System.getProperty(name));
     }
 
-    static boolean sysPropertyKeyStartingWith(String keyPrefix) {
-        for (Object key : System.getProperties().keySet()) {
-            if (key instanceof String) {
-                String stringKey = (String) key;
-                if (stringKey.startsWith(keyPrefix)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     static Optional<Boolean> booleanSysProperty(String name, ProviderFactory providers) {
         return sysProperty(name, providers).map(Boolean::parseBoolean);
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -1,6 +1,5 @@
 package com.gradle;
 
-import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.Provider;
@@ -16,7 +15,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -42,8 +42,10 @@ final class CustomBuildScanEnhancements {
     private static void captureIde(BuildScanApi buildScan) {
         if (sysProperty("idea.version").isPresent()) {
             buildScan.tag("IntelliJ IDEA");
+            buildScan.value("IntelliJ IDEA version", sysProperty("idea.version").get());
         } else if (sysProperty("eclipse.buildId").isPresent()) {
             buildScan.tag("Eclipse");
+            buildScan.value("Eclipse version", sysProperty("eclipse.buildId").get());
         } else if (!isCi()) {
             buildScan.tag("Cmd Line");
         }

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -8,7 +8,14 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.gradle.Utils.*;
+import static com.gradle.Utils.appendIfMissing;
+import static com.gradle.Utils.envVariable;
+import static com.gradle.Utils.execAndCheckSuccess;
+import static com.gradle.Utils.execAndGetStdOut;
+import static com.gradle.Utils.isNotEmpty;
+import static com.gradle.Utils.readPropertiesFile;
+import static com.gradle.Utils.sysProperty;
+import static com.gradle.Utils.urlEncode;
 
 /**
  * Adds a standard set of useful tags, links and custom values to all build scans published.
@@ -33,7 +40,7 @@ final class CustomBuildScanEnhancements {
     }
 
     private static void captureIde(BuildScanApi buildScan) {
-        if (sysProperty("idea.version").isPresent() || sysPropertyKeyStartingWith("idea.version")) {
+        if (sysProperty("idea.version").isPresent()) {
             buildScan.tag("IntelliJ IDEA");
         } else if (sysProperty("eclipse.buildId").isPresent()) {
             buildScan.tag("Eclipse");

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
@@ -25,18 +25,6 @@ final class Utils {
         return Optional.ofNullable(System.getProperty(name));
     }
 
-    static boolean sysPropertyKeyStartingWith(String keyPrefix) {
-        for (Object key : System.getProperties().keySet()) {
-            if (key instanceof String) {
-                String stringKey = (String) key;
-                if (stringKey.startsWith(keyPrefix)) {
-                    return true;
-                }
-            }
-        }
-        return false;
-    }
-
     static Optional<Boolean> booleanSysProperty(String name) {
         return sysProperty(name).map(Boolean::parseBoolean);
     }

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
@@ -10,6 +10,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
@@ -36,12 +37,16 @@ final class Utils {
         return false;
     }
 
+    static Optional<Boolean> booleanSysProperty(String name) {
+        return sysProperty(name).map(Boolean::parseBoolean);
+    }
+
+    static Optional<Duration> durationSysProperty(String name) {
+        return sysProperty(name).map(Duration::parse);
+    }
+
     static Optional<String> envVariable(String name) {
-        String value = System.getenv(name);
-        if (isNotEmpty(value)) {
-            return Optional.of(value);
-        }
-        return Optional.empty();
+        return Optional.ofNullable(System.getenv(name));
     }
 
     static String appendIfMissing(String str, String suffix) {


### PR DESCRIPTION
We want the Common Custom User Data Gradle Plugin to be compatible with as many builds as possible. This includes Gradle builds which enable configuration caching.

Fixes Issue #92