### PR TITLE
Fix reading project properties with Gradle 6.5 or higher

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -56,7 +56,7 @@ final class Utils {
 
     static Optional<String> projectProperty(String name, ProviderFactory providers, Gradle gradle) {
         if (isGradle65OrNewer()) {
-            Provider<String> property = providers.gradleProperty(name).forUseAtConfigurationTime();
+            Provider<String> property = providers.provider(() -> (String) gradle.getRootProject().findProperty(name)).forUseAtConfigurationTime();
             return Optional.ofNullable(property.getOrNull());
         }
         return Optional.ofNullable((String) gradle.getRootProject().findProperty(name));


### PR DESCRIPTION
`ProviderFactory.gradleProperty` currently does not read local project properties
(see https://github.com/gradle/gradle/issues/13302). This commit attempts to
use a workaround: Read the property within a callable that is used to create a
Provider.

Related to #93 