### PR TITLE
Reintroduce support for older IntelliJ IDEA versions

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -16,6 +16,7 @@ import static com.gradle.Utils.appendIfMissing;
 import static com.gradle.Utils.envVariable;
 import static com.gradle.Utils.execAndCheckSuccess;
 import static com.gradle.Utils.execAndGetStdOut;
+import static com.gradle.Utils.firstSysPropertyKeyStartingWith;
 import static com.gradle.Utils.isNotEmpty;
 import static com.gradle.Utils.projectProperty;
 import static com.gradle.Utils.readPropertiesFile;
@@ -50,6 +51,9 @@ final class CustomBuildScanEnhancements {
                 } else if (sysProperty("idea.version", providers).isPresent()) {
                     buildScan.tag("IntelliJ IDEA");
                     buildScan.value("IntelliJ IDEA version", sysProperty("idea.version", providers).get());
+                } else if (firstSysPropertyKeyStartingWith("idea.version", providers).isPresent()) {
+                    buildScan.tag("IntelliJ IDEA");
+                    buildScan.value("IntelliJ IDEA version", stripPrefix("idea.version", firstSysPropertyKeyStartingWith("idea.version", providers).get()));
                 } else if (sysProperty("eclipse.buildId", providers).isPresent()) {
                     buildScan.tag("Eclipse");
                     buildScan.value("Eclipse version", sysProperty("eclipse.buildId", providers).get());
@@ -58,6 +62,10 @@ final class CustomBuildScanEnhancements {
                 }
             });
         }
+    }
+
+    private static String stripPrefix(String prefix, String string) {
+        return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
     }
 
     private static void captureCiOrLocal(BuildScanExtension buildScan, ProviderFactory providers) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -48,10 +48,10 @@ final class Utils {
 
     private static Optional<String> firstKeyStartingWith(String keyPrefix, Properties properties) {
         return properties.keySet().stream()
-                .filter(s -> s instanceof String)
-                .map(s -> (String) s)
-                .filter(s -> s.startsWith(keyPrefix))
-                .findFirst();
+            .filter(s -> s instanceof String)
+            .map(s -> (String) s)
+            .filter(s -> s.startsWith(keyPrefix))
+            .findFirst();
     }
 
     static Optional<Boolean> booleanSysProperty(String name, ProviderFactory providers) {
@@ -82,6 +82,10 @@ final class Utils {
         return str.endsWith(suffix) ? str : str + suffix;
     }
 
+    static String stripPrefix(String prefix, String string) {
+        return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
+    }
+
     static String urlEncode(String str) {
         try {
             return URLEncoder.encode(str, StandardCharsets.UTF_8.name());
@@ -101,7 +105,7 @@ final class Utils {
     }
 
     static InputStream readFile(String name, ProviderFactory providers, Gradle gradle) throws FileNotFoundException {
-        if(isGradle65OrNewer()) {
+        if (isGradle65OrNewer()) {
             RegularFile file = gradle.getRootProject().getLayout().getProjectDirectory().file(name);
             Provider<byte[]> fileContent = providers.fileContents(file).getAsBytes().forUseAtConfigurationTime();
 
@@ -170,4 +174,5 @@ final class Utils {
 
     private Utils() {
     }
+
 }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -41,7 +41,7 @@ final class Utils {
         Optional<String> key = firstKeyStartingWith(keyPrefix, System.getProperties());
 
         if (isGradle65OrNewer()) {
-            key.ifPresent(k -> providers.systemProperty(k).forUseAtConfigurationTime().get());
+            key.ifPresent(k -> providers.systemProperty(k).forUseAtConfigurationTime());
         }
         return key;
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -8,7 +8,6 @@ import org.gradle.util.GradleVersion;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -36,6 +35,23 @@ final class Utils {
             return Optional.ofNullable(property.getOrNull());
         }
         return Optional.ofNullable(System.getProperty(name));
+    }
+
+    static Optional<String> firstSysPropertyKeyStartingWith(String keyPrefix, ProviderFactory providers) {
+        Optional<String> key = firstKeyStartingWith(keyPrefix, System.getProperties());
+
+        if (isGradle65OrNewer()) {
+            key.ifPresent(k -> providers.systemProperty(k).forUseAtConfigurationTime().get());
+        }
+        return key;
+    }
+
+    private static Optional<String> firstKeyStartingWith(String keyPrefix, Properties properties) {
+        return properties.keySet().stream()
+                .filter(s -> s instanceof String)
+                .map(s -> (String) s)
+                .filter(s -> s.startsWith(keyPrefix))
+                .findFirst();
     }
 
     static Optional<Boolean> booleanSysProperty(String name, ProviderFactory providers) {

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -25,43 +25,6 @@ import java.util.concurrent.TimeUnit;
 
 final class Utils {
 
-    static boolean isNotEmpty(String value) {
-        return value != null && !value.isEmpty();
-    }
-
-    static Optional<String> sysProperty(String name, ProviderFactory providers) {
-        if (isGradle65OrNewer()) {
-            Provider<String> property = providers.systemProperty(name).forUseAtConfigurationTime();
-            return Optional.ofNullable(property.getOrNull());
-        }
-        return Optional.ofNullable(System.getProperty(name));
-    }
-
-    static Optional<String> firstSysPropertyKeyStartingWith(String keyPrefix, ProviderFactory providers) {
-        Optional<String> key = firstKeyStartingWith(keyPrefix, System.getProperties());
-
-        if (isGradle65OrNewer()) {
-            key.ifPresent(k -> providers.systemProperty(k).forUseAtConfigurationTime());
-        }
-        return key;
-    }
-
-    private static Optional<String> firstKeyStartingWith(String keyPrefix, Properties properties) {
-        return properties.keySet().stream()
-            .filter(s -> s instanceof String)
-            .map(s -> (String) s)
-            .filter(s -> s.startsWith(keyPrefix))
-            .findFirst();
-    }
-
-    static Optional<Boolean> booleanSysProperty(String name, ProviderFactory providers) {
-        return sysProperty(name, providers).map(Boolean::parseBoolean);
-    }
-
-    static Optional<Duration> durationSysProperty(String name, ProviderFactory providers) {
-        return sysProperty(name, providers).map(Duration::parse);
-    }
-
     static Optional<String> envVariable(String name, ProviderFactory providers) {
         if (isGradle65OrNewer()) {
             Provider<String> variable = providers.environmentVariable(name).forUseAtConfigurationTime();
@@ -76,6 +39,42 @@ final class Utils {
             return Optional.ofNullable(property.getOrNull());
         }
         return Optional.ofNullable((String) gradle.getRootProject().findProperty(name));
+    }
+
+    static Optional<String> sysProperty(String name, ProviderFactory providers) {
+        if (isGradle65OrNewer()) {
+            Provider<String> property = providers.systemProperty(name).forUseAtConfigurationTime();
+            return Optional.ofNullable(property.getOrNull());
+        }
+        return Optional.ofNullable(System.getProperty(name));
+    }
+
+    static Optional<Boolean> booleanSysProperty(String name, ProviderFactory providers) {
+        return sysProperty(name, providers).map(Boolean::parseBoolean);
+    }
+
+    static Optional<Duration> durationSysProperty(String name, ProviderFactory providers) {
+        return sysProperty(name, providers).map(Duration::parse);
+    }
+
+    static Optional<String> firstSysPropertyKeyStartingWith(String keyPrefix, ProviderFactory providers) {
+        Optional<String> key = firstKeyStartingWith(keyPrefix, System.getProperties());
+        if (isGradle65OrNewer()) {
+            key.ifPresent(k -> providers.systemProperty(k).forUseAtConfigurationTime());
+        }
+        return key;
+    }
+
+    private static Optional<String> firstKeyStartingWith(String keyPrefix, Properties properties) {
+        return properties.keySet().stream()
+            .filter(s -> s instanceof String)
+            .map(s -> (String) s)
+            .filter(s -> s.startsWith(keyPrefix))
+            .findFirst();
+    }
+
+    static boolean isNotEmpty(String value) {
+        return value != null && !value.isEmpty();
     }
 
     static String appendIfMissing(String str, String suffix) {

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -12,6 +12,7 @@ import static com.gradle.Utils.appendIfMissing;
 import static com.gradle.Utils.envVariable;
 import static com.gradle.Utils.execAndCheckSuccess;
 import static com.gradle.Utils.execAndGetStdOut;
+import static com.gradle.Utils.firstSysPropertyKeyStartingWith;
 import static com.gradle.Utils.isNotEmpty;
 import static com.gradle.Utils.readPropertiesFile;
 import static com.gradle.Utils.sysProperty;
@@ -47,10 +48,17 @@ final class CustomBuildScanEnhancements {
             } else if (sysProperty("eclipse.buildId").isPresent()) {
                 buildScan.tag("Eclipse");
                 buildScan.value("Eclipse version", sysProperty("eclipse.buildId").get());
+            } else if (firstSysPropertyKeyStartingWith("idea.version").isPresent()) {
+                buildScan.tag("IntelliJ IDEA");
+                buildScan.value("IntelliJ IDEA version", stripPrefix("idea.version", firstSysPropertyKeyStartingWith("idea.version").get()));
             } else {
                 buildScan.tag("Cmd Line");
             }
         }
+    }
+
+    private static String stripPrefix(String prefix, String string) {
+        return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
     }
 
     private static void captureCiOrLocal(BuildScanApi buildScan) {

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
@@ -17,20 +17,12 @@ import java.util.concurrent.TimeUnit;
 
 final class Utils {
 
-    static boolean isNotEmpty(String value) {
-        return value != null && !value.isEmpty();
+    static Optional<String> envVariable(String name) {
+        return Optional.ofNullable(System.getenv(name));
     }
 
     static Optional<String> sysProperty(String name) {
         return Optional.ofNullable(System.getProperty(name));
-    }
-
-    static Optional<String> firstSysPropertyKeyStartingWith(String keyPrefix) {
-        return System.getProperties().keySet().stream()
-            .filter(s -> s instanceof String)
-            .map(s -> (String) s)
-            .filter(s -> s.startsWith(keyPrefix))
-            .findFirst();
     }
 
     static Optional<Boolean> booleanSysProperty(String name) {
@@ -41,8 +33,16 @@ final class Utils {
         return sysProperty(name).map(Duration::parse);
     }
 
-    static Optional<String> envVariable(String name) {
-        return Optional.ofNullable(System.getenv(name));
+    static Optional<String> firstSysPropertyKeyStartingWith(String keyPrefix) {
+        return System.getProperties().keySet().stream()
+            .filter(s -> s instanceof String)
+            .map(s -> (String) s)
+            .filter(s -> s.startsWith(keyPrefix))
+            .findFirst();
+    }
+
+    static boolean isNotEmpty(String value) {
+        return value != null && !value.isEmpty();
     }
 
     static String appendIfMissing(String str, String suffix) {

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
@@ -27,10 +27,10 @@ final class Utils {
 
     static Optional<String> firstSysPropertyKeyStartingWith(String keyPrefix) {
         return System.getProperties().keySet().stream()
-                .filter(s -> s instanceof String)
-                .map(s -> (String) s)
-                .filter(s -> s.startsWith(keyPrefix))
-                .findFirst();
+            .filter(s -> s instanceof String)
+            .map(s -> (String) s)
+            .filter(s -> s.startsWith(keyPrefix))
+            .findFirst();
     }
 
     static Optional<Boolean> booleanSysProperty(String name) {
@@ -47,6 +47,10 @@ final class Utils {
 
     static String appendIfMissing(String str, String suffix) {
         return str.endsWith(suffix) ? str : str + suffix;
+    }
+
+    static String stripPrefix(String prefix, String string) {
+        return string.startsWith(prefix) ? string.substring(prefix.length()) : string;
     }
 
     static String urlEncode(String str) {

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
@@ -25,6 +25,14 @@ final class Utils {
         return Optional.ofNullable(System.getProperty(name));
     }
 
+    static Optional<String> firstSysPropertyKeyStartingWith(String keyPrefix) {
+        return System.getProperties().keySet().stream()
+                .filter(s -> s instanceof String)
+                .map(s -> (String) s)
+                .filter(s -> s.startsWith(keyPrefix))
+                .findFirst();
+    }
+
     static Optional<Boolean> booleanSysProperty(String name) {
         return sysProperty(name).map(Boolean::parseBoolean);
     }


### PR DESCRIPTION
For Gradle, the new configuration-cache-compatible solution uses the fact that
there should only ever be one system property that starts with `idea.version`.
If one exists, then the Plugin lets Gradle know that it should include the
property when calculating the configuration cache key. If the user upgrades
IntelliJ, then the previous system property will be removed and the
configuration cache will be invalidated. If a new property takes its place,
then that one will be declared.

For both Maven and Gradle, if an `idea.versionYYYY.NN` System property is
found, then the System property's key is parsed to populate the "IntelliJ IDEA
version" custom value.

Related to #92 