### PR TITLE
Use buildId instead of buildNumber for TeamCity

### DIFF
--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -79,6 +79,7 @@ final class CustomBuildScanEnhancements {
         if (isTeamCity()) {
             Optional<String> teamCityConfigFile = projectProperty(mavenSession, "teamcity.configuration.properties.file");
             Optional<String> buildId = projectProperty(mavenSession, "teamcity.build.id");
+            Optional<String> buildNumber = projectProperty(mavenSession, "build.number");
             Optional<String> buildTypeId = projectProperty(mavenSession, "teamcity.buildType.id");
             if (teamCityConfigFile.isPresent()
                 && buildId.isPresent()

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -78,15 +78,15 @@ final class CustomBuildScanEnhancements {
 
         if (isTeamCity()) {
             Optional<String> teamCityConfigFile = projectProperty(mavenSession, "teamcity.configuration.properties.file");
-            Optional<String> buildNumber = projectProperty(mavenSession, "build.number");
+            Optional<String> buildId = projectProperty(mavenSession, "teamcity.build.id");
             Optional<String> buildTypeId = projectProperty(mavenSession, "teamcity.buildType.id");
             if (teamCityConfigFile.isPresent()
-                && buildNumber.isPresent()
+                && buildId.isPresent()
                 && buildTypeId.isPresent()) {
                 Properties properties = readPropertiesFile(teamCityConfigFile.get());
                 String teamCityServerUrl = properties.getProperty("teamcity.serverUrl");
                 if (teamCityServerUrl != null) {
-                    String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildNumber=" + buildNumber.get() + "&buildTypeId=" + buildTypeId.get();
+                    String buildUrl = appendIfMissing(teamCityServerUrl, "/") + "viewLog.html?buildId=" + buildId.get() + "&buildTypeId=" + buildTypeId.get();
                     buildScan.link("TeamCity build", buildUrl);
                 }
             }


### PR DESCRIPTION
buildNumber in TeamCity may be any String with whitespace characters. Thus it is better to use buildId instead.