### PR TITLE
Generate a "fat" jar for the CCUD Maven extension

### DIFF
--- a/common-custom-user-data-maven-extension/.gitignore
+++ b/common-custom-user-data-maven-extension/.gitignore
@@ -16,6 +16,7 @@ pom.xml.releaseBackup
 pom.xml.versionsBackup
 pom.xml.next
 release.properties
+dependency-reduced-pom.xml
 
 # OS X
 # ----

--- a/common-custom-user-data-maven-extension/CHANGELOG.md
+++ b/common-custom-user-data-maven-extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Publish a "fat" jar that contains all of the extension's dependencies (to make it easier to use the extension in certian scenarios).
 
 ## [1.7.1] - 2021-06-22
 - Encode (escape) the TeamCity build number when creating a link to the TeamCity build (fixes Issue #101).

--- a/common-custom-user-data-maven-extension/pom.xml
+++ b/common-custom-user-data-maven-extension/pom.xml
@@ -114,6 +114,16 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.4</version>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>org.codehaus.groovy:groovy</artifact>
+                            <excludes>
+                                <exclude>META-INF/MANIFEST.MF</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/common-custom-user-data-maven-extension/pom.xml
+++ b/common-custom-user-data-maven-extension/pom.xml
@@ -110,6 +110,19 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
In addition to adding the extension to the extensions.xml file, the CCUD Maven
extension can be used by putting it in the MAVEN_HOME/lib/ext directory, or by
referencing the jar on the command line by setting the `maven.ext.class.path`
system property when invoking Maven.

Unfortunately, if the extension is used via one of these two additonal methods,
then Maven is unable to resolve any dependencies of the CCUD Maven extension.
That means the extension could fail with a ClassDefNotFound error.

Users could add all of the extensions dependencies to their MAVEN_HOME/lib
folder, but we can make it easier on users if we publish a jar that contains
all of the extension's dependencies (which is currently only Groovy).