### PR TITLE
Fix configuration cache bug when capturing Test maxParallelForks

### DIFF
--- a/common-custom-user-data-gradle-plugin/CHANGELOG.md
+++ b/common-custom-user-data-gradle-plugin/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Fix configuration cache compatibility when capturing test maxParallelForks.
 
 ## [1.4.1] - 2021-06-22
 - Encode (escape) the TeamCity build number when creating a link to the TeamCity build (fixes Issue #101).

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -40,7 +40,7 @@ final class CustomBuildScanEnhancements {
         captureCiOrLocal();
         captureCiMetadata();
         captureGitMetadata();
-        captureTestParallelization();
+        captureTestParallelization(gradle, buildScan);
     }
 
     private void captureOs() {
@@ -301,7 +301,7 @@ final class CustomBuildScanEnhancements {
         }
     }
 
-    private void captureTestParallelization() {
+    private static void captureTestParallelization(Gradle gradle, BuildScanExtension buildScan) {
         gradle.allprojects(p ->
             p.getTasks().withType(Test.class).configureEach(test ->
                 test.doFirst(new Action<Task>() {


### PR DESCRIPTION
captureTestParallelization needs to be static so that the anonymous inner Action subclass can be serialized without maintaining a reference to the CustomBuildScanEnhancements instance.