### PR TITLE
Use dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  gradle-plugin-portal:
+    type: maven-repository
+    url: https://plugins.gradle.org/m2
+    username: dummy # Required by dependabot
+    password: dummy # Required by dependabot
 updates:
   - package-ecosystem: "maven"
     directory: "common-custom-user-data-maven-extension"
@@ -12,6 +18,13 @@ updates:
     target-branch: "dependabot-updates"
   - package-ecosystem: "maven"
     directory: "maven-build-caching-samples"
+    schedule:
+      interval: "daily"
+    target-branch: "dependabot-updates"
+  - package-ecosystem: "gradle"
+    directory: "common-custom-user-data-gradle-plugin"
+    registries:
+      - gradle-plugin-portal
     schedule:
       interval: "daily"
     target-branch: "dependabot-updates"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "common-custom-user-data-maven-extension"
+    schedule:
+      interval: "daily"
+    target-branch: "dependabot-updates"
+  - package-ecosystem: "maven"
+    directory: "common-gradle-enterprise-maven-configuration"
+    schedule:
+      interval: "daily"
+    target-branch: "dependabot-updates"
+  - package-ecosystem: "maven"
+    directory: "maven-build-caching-samples"
+    schedule:
+      interval: "daily"
+    target-branch: "dependabot-updates"


### PR DESCRIPTION
Will provide PRs for outdated dependencies in:
- Maven pom.xml and extensions.xml files
- Gradle build.gradle files

Will not update plugin versions in settings.gradle files, or Gradle/Maven wrapper versions.