### PR TITLE
Provide a SLF4J logger to CCUDME Groovy scripts

### DIFF
--- a/common-custom-user-data-maven-extension/CHANGELOG.md
+++ b/common-custom-user-data-maven-extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Change the type of the `log` variable bound for custom Groovy scripts to `org.slf4j.Logger`. This change may require changes in custom Groovy scripts.
 
 ## [1.8.1] - 2021-10-13
 - Avoid use of `org.apache.maven.monitor.logging.DefaultLog` since this type has been renamed in Maven 4 (#165)

--- a/common-custom-user-data-maven-extension/README.md
+++ b/common-custom-user-data-maven-extension/README.md
@@ -48,7 +48,7 @@ the script with the following bindings:
 - `gradleEnterprise` (type: [GradleEnterpriseApi](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/GradleEnterpriseApi.html)): _configure Gradle Enterprise_
 - `buildScan` (type: [BuildScanApi](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/scan/BuildScanApi.html)): _configure build scan publishing and enhance build scans_
 - `buildCache` (type: [BuildCacheApi](https://docs.gradle.com/enterprise/maven-extension/api/com/gradle/maven/extension/api/cache/BuildCacheApi.html)): _configure build cache_
-- `log` (type: [`Log`](https://maven.apache.org/ref/current/maven-plugin-api/apidocs/org/apache/maven/plugin/logging/Log.html)): _write to the build log_
+- `log` (type: [`Logger`](http://www.slf4j.org/apidocs/org/slf4j/Logger.html)): _write to the build log_
 - `project` (type: [`MavenProject`](https://maven.apache.org/ref/current/maven-core/apidocs/org/apache/maven/project/MavenProject.html)): _the top-level Maven project_
 - `session` (type: [`MavenSession`](https://maven.apache.org/ref/current/maven-core/apidocs/org/apache/maven/execution/MavenSession.html)): _the Maven session_
 

--- a/common-custom-user-data-maven-extension/pom.xml
+++ b/common-custom-user-data-maven-extension/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.gradle</groupId>
     <artifactId>common-custom-user-data-maven-extension</artifactId>
     <packaging>jar</packaging>
-    <version>1.8.2-SNAPSHOT</version>
+    <version>1.9-SNAPSHOT</version>
     <name>Gradle Enterprise Common Custom User Data Maven Extension</name>
     <description>A Maven extension to capture common custom user data used for Maven Build Scans in Gradle Enterprise</description>
     <url>https://github.com/gradle/gradle-build-scan-snippets/tree/master/common-custom-user-data-maven-extension</url>

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CommonCustomUserDataGradleEnterpriseListener.java
@@ -6,8 +6,8 @@ import com.gradle.maven.extension.api.cache.BuildCacheApi;
 import com.gradle.maven.extension.api.scan.BuildScanApi;
 import org.apache.maven.execution.MavenSession;
 import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("unused")
 @Component(
@@ -17,8 +17,7 @@ import org.codehaus.plexus.logging.Logger;
 )
 public final class CommonCustomUserDataGradleEnterpriseListener implements GradleEnterpriseListener {
 
-    @Requirement
-    private Logger logger;
+    private final Logger logger = LoggerFactory.getLogger(CommonCustomUserDataGradleEnterpriseListener.class);
 
     @Override
     public void configure(GradleEnterpriseApi api, MavenSession session) throws Exception {

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/GroovyScriptUserData.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/GroovyScriptUserData.java
@@ -5,8 +5,7 @@ import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import org.apache.maven.MavenExecutionException;
 import org.apache.maven.execution.MavenSession;
-import org.apache.maven.plugin.logging.Log;
-import org.codehaus.plexus.logging.Logger;
+import org.slf4j.Logger;
 
 import java.io.File;
 
@@ -43,91 +42,11 @@ final class GroovyScriptUserData {
         binding.setVariable("gradleEnterprise", gradleEnterprise);
         binding.setVariable("buildScan", gradleEnterprise.getBuildScan());
         binding.setVariable("buildCache", gradleEnterprise.getBuildCache());
-        binding.setVariable("log", new MavenLogger(logger));
+        binding.setVariable("log", logger);
         return binding;
     }
 
     private GroovyScriptUserData() {
-    }
-
-    /**
-     * Since there's no consistent implementation type across different versions of Maven,
-     * we use an internal implementation of Maven {@link Log} that wraps the Plexus {@link Logger}.
-     */
-    private static final class MavenLogger implements Log {
-        private final Logger plexusLogger;
-
-        private MavenLogger(Logger plexusLogger) {
-            this.plexusLogger = plexusLogger;
-        }
-
-        public void debug(CharSequence content) {
-            plexusLogger.debug(toString(content));
-        }
-
-        private String toString(CharSequence content) {
-            return content == null ? "" : content.toString();
-        }
-
-        public void debug(CharSequence content, Throwable error) {
-            plexusLogger.debug(toString(content), error);
-        }
-
-        public void debug(Throwable error) {
-            plexusLogger.debug("", error);
-        }
-
-        public void info(CharSequence content) {
-            plexusLogger.info(toString(content));
-        }
-
-        public void info(CharSequence content, Throwable error) {
-            plexusLogger.info(toString(content), error);
-        }
-
-        public void info(Throwable error) {
-            plexusLogger.info("", error);
-        }
-
-        public void warn(CharSequence content) {
-            plexusLogger.warn(toString(content));
-        }
-
-        public void warn(CharSequence content, Throwable error) {
-            plexusLogger.warn(toString(content), error);
-        }
-
-        public void warn(Throwable error) {
-            plexusLogger.warn("", error);
-        }
-
-        public void error(CharSequence content) {
-            plexusLogger.error(toString(content));
-        }
-
-        public void error(CharSequence content, Throwable error) {
-            plexusLogger.error(toString(content), error);
-        }
-
-        public void error(Throwable error) {
-            plexusLogger.error("", error);
-        }
-
-        public boolean isDebugEnabled() {
-            return plexusLogger.isDebugEnabled();
-        }
-
-        public boolean isInfoEnabled() {
-            return plexusLogger.isInfoEnabled();
-        }
-
-        public boolean isWarnEnabled() {
-            return plexusLogger.isWarnEnabled();
-        }
-
-        public boolean isErrorEnabled() {
-            return plexusLogger.isErrorEnabled();
-        }
     }
 
 }


### PR DESCRIPTION
When a groovy script is used to add custom tags/links/values via the
common-custom-user-data-maven-extension, a `log` variable is bound to allow
custom messages to be logged.

Previously this was of type `org.apache.maven.plugin.logging.Log`, using a `DefaultLog`
instance to wrap a Plexus Logger. With this change, we provide a standard `org.slf4j.Logger`
instance to Groovy scripts instead, reducing our dependency on core Maven types.

This is a minor breaking change as the `org.slf4j.Logger` type differs slightly from
`org.apache.maven.plugin.logging.Log`, and some groovy scripts will no longer function.