### PR TITLE
Apply build scan enhancements after settings are evaluated

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -42,10 +42,6 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
             customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
-            BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-            customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle()).apply();
-
             BuildCacheConfiguration buildCache = settings.getBuildCache();
             customGradleEnterpriseConfig.configureBuildCache(buildCache);
 
@@ -55,6 +51,12 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
                 SystemPropertyOverrides overrides = new SystemPropertyOverrides(providers);
                 overrides.configureGradleEnterprise(gradleEnterprise);
                 overrides.configureBuildCache(buildCache);
+
+                // Build scan enhancements depend on the finalized configuration of the gradleEnterprise extension,
+                // so must be executed after the `Settings` has been completely evaluated.
+                BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
+                customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+                new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle()).apply();
             });
         });
     }


### PR DESCRIPTION
Previously, the build scan enhancements were applied immediately on plugin application.
This meant that custom-link rules that required the GE server URL could not be
run, as the server property had not yet been set.

With this change, all build scan enhancements are run after the settings has been
evaluated. At this stage, the gradleEnterprise extension should be fully configured.

Fixes #187