### PR TITLE
Add custom value and link for GITHUB_RUN_ID

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -151,7 +151,9 @@ final class CustomBuildScanEnhancements {
                 buildScan.link("GitHub Actions build", "https://github.com/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
             }
             envVariable("GITHUB_WORKFLOW").ifPresent(value ->
-                addCustomValueAndSearchLink("GitHub workflow", value));
+                addCustomValueAndSearchLink("CI workflow", value));
+            envVariable("GITHUB_RUN_ID").ifPresent(value ->
+                addCustomValueAndSearchLink("CI run", value));
         }
 
         if (isGitLab()) {


### PR DESCRIPTION
Also renamed the existing workflow search link to be consistent with other CI systems. So:

- `GITHUB_WORKFLOW` => `CI Workflow build scans`
- `GITHUB_RUN_ID` => `CI Run build scans`