### PR TITLE
Add custom value and link for GitHub actions run_id

### DIFF
--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -138,7 +138,9 @@ final class CustomBuildScanEnhancements {
                 buildScan.link("GitHub Actions build", "https://github.com/" + gitHubRepository.get() + "/actions/runs/" + gitHubRunId.get());
             }
             envVariable("GITHUB_WORKFLOW").ifPresent(value ->
-                addCustomValueAndSearchLink("GitHub workflow", value));
+                addCustomValueAndSearchLink("CI workflow", value));
+            envVariable("GITHUB_RUN_ID").ifPresent(value ->
+                addCustomValueAndSearchLink("CI run", value));
         }
 
         if (isGitLab()) {


### PR DESCRIPTION
Note that I made the equivalent change (without review!) on the Gradle Plugin side already.

This PR also renames the existing "Workflow" search link to be consistent with other CI systems. So:

- `GITHUB_WORKFLOW` => `CI Workflow build scans`
- `GITHUB_RUN_ID` => `CI Run build scans`