### PR TITLE
Add tag when Intellij Idea sync build is detected

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -57,7 +57,10 @@ final class CustomBuildScanEnhancements {
                 Optional<String> newIdeaVersion = sysProperty("idea.version");
                 Optional<String> oldIdeaVersion = firstSysPropertyKeyStartingWith("idea.version");
                 Optional<String> eclipseVersion = sysProperty("eclipse.buildId");
-
+                Optional<String> ideaSync = sysProperty("idea.sync.active");
+                if (ideaSync.isPresent()) {
+                    buildScan.tag("IDE sync");
+                }
                 if (invokedFromAndroidStudio.isPresent()) {
                     buildScan.tag("Android Studio");
                     androidStudioVersion.ifPresent(v -> buildScan.value("Android Studio version", v));


### PR DESCRIPTION
We should provide a specific tag on build scans resulting from an IDEA sync (when hitting the "Reload All Gradle Projects" button)