### PR TITLE
Second attempt at fixing custom link generation

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -44,7 +44,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle()).apply();
+            CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle());
+            buildScanEnhancements.apply();
 
             BuildCacheConfiguration buildCache = settings.getBuildCache();
             customGradleEnterpriseConfig.configureBuildCache(buildCache);
@@ -55,6 +56,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
                 SystemPropertyOverrides overrides = new SystemPropertyOverrides(providers);
                 overrides.configureGradleEnterprise(gradleEnterprise);
                 overrides.configureBuildCache(buildCache);
+
+                buildScanEnhancements.runPostEvaluateActions();
             });
         });
     }
@@ -71,7 +74,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
 
             BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
             customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-            new CustomBuildScanEnhancements(buildScan, providers, project.getGradle()).apply();
+            CustomBuildScanEnhancements buildScanEnhancements = new CustomBuildScanEnhancements(buildScan, providers, project.getGradle());
+            buildScanEnhancements.apply();
 
             // Build cache configuration cannot be accessed from a project plugin
 
@@ -80,6 +84,8 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             project.afterEvaluate(___ -> {
                 SystemPropertyOverrides overrides = new SystemPropertyOverrides(providers);
                 overrides.configureGradleEnterprise(gradleEnterprise);
+
+                buildScanEnhancements.runPostEvaluateActions();
             });
         });
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -42,6 +42,10 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             GradleEnterpriseExtension gradleEnterprise = settings.getExtensions().getByType(GradleEnterpriseExtension.class);
             customGradleEnterpriseConfig.configureGradleEnterprise(gradleEnterprise);
 
+            BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
+            customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
+            new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle()).apply();
+
             BuildCacheConfiguration buildCache = settings.getBuildCache();
             customGradleEnterpriseConfig.configureBuildCache(buildCache);
 
@@ -51,12 +55,6 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
                 SystemPropertyOverrides overrides = new SystemPropertyOverrides(providers);
                 overrides.configureGradleEnterprise(gradleEnterprise);
                 overrides.configureBuildCache(buildCache);
-
-                // Build scan enhancements depend on the finalized configuration of the gradleEnterprise extension,
-                // so must be executed after the `Settings` has been completely evaluated.
-                BuildScanExtension buildScan = gradleEnterprise.getBuildScan();
-                customGradleEnterpriseConfig.configureBuildScanPublishing(buildScan);
-                new CustomBuildScanEnhancements(buildScan, providers, settings.getGradle()).apply();
             });
         });
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -46,12 +46,10 @@ final class CustomBuildScanEnhancements {
         captureCiMetadata();
         captureGitMetadata();
         captureTestParallelization();
-
-        gradle.settingsEvaluated(settings -> runPostEvaluateActions());
     }
 
     // Run any actions that require the `gradleEnterprise` extension to be fully configured.
-    private void runPostEvaluateActions() {
+    void runPostEvaluateActions() {
         for (Action<BuildScanExtension> postEvaluateAction : postEvaluateActions) {
             postEvaluateAction.execute(buildScan);
         }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -241,7 +241,10 @@ final class CustomBuildScanEnhancements {
     }
 
     private void captureGitMetadata() {
-        buildScan.background(new CaptureGitMetadataAction(providers));
+        // Do not start capturing Git metadata until settings have been evaluated since
+        // creating the "Git Commit id build scans" link requires the server url to be set.
+        postEvaluateActions.add(buildScan ->
+            buildScan.background(new CaptureGitMetadataAction(providers)));
     }
 
     private static final class CaptureGitMetadataAction implements Action<BuildScanExtension> {


### PR DESCRIPTION
This is another attempt at fixing #187. Instead of deferring all build scan customization, we only defer the creation of custom links that require the server url to be configured.

The final commit in this PR also defers the capture of Git commit metadata, avoid a potential (but rare) race condition.
This is not perfect, and we could either:
- Ignore this potential race condition, and not change the capture of Git commit metadata
- Implement a thread-safe solution to defer only the generation of the "git commit id build scans" link