### PR TITLE
Redact any user:password contained in Git repo URL

### DIFF
--- a/common-custom-user-data-gradle-plugin/CHANGELOG.md
+++ b/common-custom-user-data-gradle-plugin/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add custom value and search link for GitHub Actions run ID.
-- Fix generation of search links for custom values (#187).
+- Fix generation of search links for custom values.
 - Redact any `user:password@` portion of the 'Git repository' custom value.
 
 ## [1.4.2] - 2021-07-13

--- a/common-custom-user-data-gradle-plugin/CHANGELOG.md
+++ b/common-custom-user-data-gradle-plugin/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Add custom value and search link for GitHub Actions run ID.
 - Fix generation of search links for custom values (#187).
+- Redact any `user:password@` portion of the 'Git repository' custom value.
 
 ## [1.4.2] - 2021-07-13
 - Fix configuration cache compatibility when capturing test maxParallelForks.

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -19,6 +19,7 @@ import static com.gradle.Utils.appendIfMissing;
 import static com.gradle.Utils.execAndCheckSuccess;
 import static com.gradle.Utils.execAndGetStdOut;
 import static com.gradle.Utils.isNotEmpty;
+import static com.gradle.Utils.redactUserInfo;
 import static com.gradle.Utils.stripPrefix;
 import static com.gradle.Utils.urlEncode;
 
@@ -269,7 +270,7 @@ final class CustomBuildScanEnhancements {
             String gitStatus = execAndGetStdOut("git", "status", "--porcelain");
 
             if (isNotEmpty(gitRepo)) {
-                buildScan.value("Git repository", gitRepo);
+                buildScan.value("Git repository", redactUserInfo(gitRepo));
             }
             if (isNotEmpty(gitCommitId)) {
                 buildScan.value("Git commit id", gitCommitId);

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -106,14 +106,12 @@ final class Utils {
         }
     }
 
-    /**
-     * Redact any `user:password` that is part of the URL.
-     */
     static String redactUserInfo(String url) {
         try {
-            URI uri = new URI(url);
-            String userInfoPart = uri.getUserInfo() + '@';
-            return url.replace(userInfoPart, "******@");
+            String userInfo = new URI(url).getUserInfo();
+            return userInfo == null
+                ? url
+                : url.replace(userInfo + '@', "******@");
         } catch (URISyntaxException e) {
             return url;
         }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/Utils.java
@@ -16,6 +16,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -102,6 +103,19 @@ final class Utils {
             return URLEncoder.encode(str, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Redact any `user:password` that is part of the URL.
+     */
+    static String redactUserInfo(String url) {
+        try {
+            URI uri = new URI(url);
+            String userInfoPart = uri.getUserInfo() + '@';
+            return url.replace(userInfoPart, "******@");
+        } catch (URISyntaxException e) {
+            return url;
         }
     }
 

--- a/common-custom-user-data-maven-extension/CHANGELOG.md
+++ b/common-custom-user-data-maven-extension/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Change the type of the `log` variable bound for custom Groovy scripts to `org.slf4j.Logger`. This change may require changes in custom Groovy scripts.
 - Add custom value and search link for GitHub Actions run ID.
+- Redact any `user:password@` portion of the 'Git repository' custom value.
 
 ## [1.8.1] - 2021-10-13
 - Avoid use of `org.apache.maven.monitor.logging.DefaultLog` since this type has been renamed in Maven 4 (#165)

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -17,6 +17,7 @@ import static com.gradle.Utils.execAndGetStdOut;
 import static com.gradle.Utils.firstSysPropertyKeyStartingWith;
 import static com.gradle.Utils.isNotEmpty;
 import static com.gradle.Utils.readPropertiesFile;
+import static com.gradle.Utils.redactUserInfo;
 import static com.gradle.Utils.stripPrefix;
 import static com.gradle.Utils.sysProperty;
 import static com.gradle.Utils.urlEncode;
@@ -235,7 +236,7 @@ final class CustomBuildScanEnhancements {
             String gitStatus = execAndGetStdOut("git", "status", "--porcelain");
 
             if (isNotEmpty(gitRepo)) {
-                buildScan.value("Git repository", gitRepo);
+                buildScan.value("Git repository", redactUserInfo(gitRepo));
             }
             if (isNotEmpty(gitCommitId)) {
                 buildScan.value("Git commit id", gitCommitId);

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
@@ -79,14 +79,12 @@ final class Utils {
         }
     }
 
-    /**
-     * Redact any `user:password` that is part of the URL.
-     */
     static String redactUserInfo(String url) {
         try {
-            URI uri = new URI(url);
-            String userInfoPart = uri.getUserInfo() + '@';
-            return url.replace(userInfoPart, "******@");
+            String userInfo = new URI(url).getUserInfo();
+            return userInfo == null
+                ? url
+                : url.replace(userInfo + '@', "******@");
         } catch (URISyntaxException e) {
             return url;
         }

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/Utils.java
@@ -10,6 +10,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -75,6 +76,19 @@ final class Utils {
             return URLEncoder.encode(str, StandardCharsets.UTF_8.name());
         } catch (UnsupportedEncodingException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Redact any `user:password` that is part of the URL.
+     */
+    static String redactUserInfo(String url) {
+        try {
+            URI uri = new URI(url);
+            String userInfoPart = uri.getUserInfo() + '@';
+            return url.replace(userInfoPart, "******@");
+        } catch (URISyntaxException e) {
+            return url;
         }
     }
 


### PR DESCRIPTION
This user information should not be included as part of the 'Git Repository'
custom value. With this change, any `user:password@` part of the URL will
be replaced by `******@`.

This change was based on PR #160.

Normalizing all 'Git Repository' values is not part of this fix. A later change
could potentially normalize all Git connection URLs to the canonical Git Repository URL.