### PR TITLE
Use 'buildScan.buildFinished' for deferred actions

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CommonCustomUserDataGradlePlugin.java
@@ -56,9 +56,6 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
                 SystemPropertyOverrides overrides = new SystemPropertyOverrides(providers);
                 overrides.configureGradleEnterprise(gradleEnterprise);
                 overrides.configureBuildCache(buildCache);
-
-                // do the enhancements that can only be done once all configuration has been fully applied
-                buildScanEnhancements.runPostEvaluateActions();
             });
         });
     }
@@ -85,9 +82,6 @@ public class CommonCustomUserDataGradlePlugin implements Plugin<Object> {
             project.afterEvaluate(___ -> {
                 SystemPropertyOverrides overrides = new SystemPropertyOverrides(providers);
                 overrides.configureGradleEnterprise(gradleEnterprise);
-
-                // do the enhancements that can only be done once all configuration has been fully applied
-                buildScanEnhancements.runPostEvaluateActions();
             });
         });
     }

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -7,8 +7,6 @@ import org.gradle.api.invocation.Gradle;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.testing.Test;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Supplier;
@@ -31,8 +29,6 @@ final class CustomBuildScanEnhancements {
     private final ProviderFactory providers;
     private final Gradle gradle;
 
-    private final List<Action<BuildScanExtension>> postEvaluateActions = new ArrayList<>();
-
     CustomBuildScanEnhancements(BuildScanExtension buildScan, ProviderFactory providers, Gradle gradle) {
         this.buildScan = buildScan;
         this.providers = providers;
@@ -47,13 +43,6 @@ final class CustomBuildScanEnhancements {
         captureCiMetadata();
         captureGitMetadata();
         captureTestParallelization();
-    }
-
-    // Run any actions that require the `gradleEnterprise` extension to be fully configured
-    void runPostEvaluateActions() {
-        for (Action<BuildScanExtension> action : postEvaluateActions) {
-            action.execute(buildScan);
-        }
     }
 
     private void captureOs() {
@@ -242,10 +231,7 @@ final class CustomBuildScanEnhancements {
     }
 
     private void captureGitMetadata() {
-        // Do not start capturing Git metadata until settings have been evaluated since
-        // creating customs links requires the server url to be set
-        postEvaluateActions.add(buildScan ->
-            buildScan.background(new CaptureGitMetadataAction(providers)));
+        buildScan.background(new CaptureGitMetadataAction(providers));
     }
 
     private static final class CaptureGitMetadataAction implements Action<BuildScanExtension> {
@@ -275,8 +261,7 @@ final class CustomBuildScanEnhancements {
                 buildScan.value("Git commit id", gitCommitId);
             }
             if (isNotEmpty(gitCommitShortId)) {
-                buildScan.value("Git commit id short", gitCommitShortId);
-                addSearchLinkForCustomValue(buildScan, "Git commit id", "Git commit id short", gitCommitShortId);
+                addCustomValueAndSearchLink(buildScan, "Git commit id", "Git commit id short", gitCommitShortId);
             }
             if (isNotEmpty(gitBranchName)) {
                 buildScan.tag(gitBranchName);
@@ -331,14 +316,14 @@ final class CustomBuildScanEnhancements {
     }
 
     private void addCustomValueAndSearchLink(String name, String value) {
-        addCustomValueAndSearchLink(name, name, value);
+        addCustomValueAndSearchLink(buildScan, name, name, value);
     }
 
-    private void addCustomValueAndSearchLink(String linkLabel, String name, String value) {
-        // Set custom values immediately, but do not add custom links until settings have been evaluated since
-        // creating customs links requires the server url to be set
+    private static void addCustomValueAndSearchLink(BuildScanExtension buildScan, String linkLabel, String name, String value) {
+        // Set custom values immediately, but do not add custom links until 'buildFinished' since
+        // creating customs links requires the server url to be fully configured
         buildScan.value(name, value);
-        postEvaluateActions.add(buildScan -> addSearchLinkForCustomValue(buildScan, linkLabel, name, value));
+        buildScan.buildFinished(result -> addSearchLinkForCustomValue(buildScan, linkLabel, name, value));
     }
 
     private static void addSearchLinkForCustomValue(BuildScanExtension buildScan, String linkLabel, String name, String value) {

--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -296,15 +296,17 @@ final class CustomBuildScanEnhancements {
     }
 
     private void addCustomValueAndSearchLink(String name, String value) {
-        addCustomValueAndSearchLink(name, name, value);
-    }
-
-    private void addCustomValueAndSearchLink(String linkLabel, String name, String value) {
-        addCustomValueAndSearchLink(buildScan, linkLabel, name, value);
+        addCustomValueAndSearchLink(buildScan, name, name, value);
     }
 
     private static void addCustomValueAndSearchLink(BuildScanApi buildScan, String linkLabel, String name, String value) {
+        // Set custom values immediately, but do not add custom links until 'buildFinished' since
+        // creating customs links requires the server url to be fully configured
         buildScan.value(name, value);
+        buildScan.buildFinished(result -> addSearchLinkForCustomValue(buildScan, linkLabel, name, value));
+    }
+
+    private static void addSearchLinkForCustomValue(BuildScanApi buildScan, String linkLabel, String name, String value) {
         String server = buildScan.getServer();
         if (server != null) {
             String searchParams = "search.names=" + urlEncode(name) + "&search.values=" + urlEncode(value);


### PR DESCRIPTION
To ensure that the correct build scan server is used when generating
custom value search links, we need to wait until no further changes will
be made to the server configuration.

Instead of `settingsEvaluated` and `afterEvalutate`, this change makes use
of `BuildScanExtension.buildFinished` to defer this work. This ensures that even
if the server URL is set during build execution the correct value will be used.

I considered keeping the mechanism to collect all of the different link-create actions into a single composite action to run with `buildFinished`. However, the mechanism for queuing multiple `buildFinished` actions is lightweight, so this seemed unnecessary.