### PR TITLE
Build CCUD Gradle plugin with Java 8

### DIFF
--- a/common-custom-user-data-gradle-plugin/build.gradle
+++ b/common-custom-user-data-gradle-plugin/build.gradle
@@ -17,6 +17,12 @@ dependencies {
     compileOnly 'com.gradle:gradle-enterprise-gradle-plugin:3.7.1'
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(8)
+    }
+}
+
 gradlePlugin {
     plugins {
         commonCustomUserData {


### PR DESCRIPTION
Use the 'java.toolchain' feature of Gradle to always build the plugin
with a Java 1.8 JDK.

This allows us to run the build with newer JDK versions, and will
make it easier to catch inadvertant use of newer JDK features/APIs.

We are already [doing the equivalent for the CCUD Maven extension](https://github.com/gradle/gradle-enterprise-build-config-samples/blob/master/common-custom-user-data-maven-extension/pom.xml#L90-L91).