### PR TITLE
Fix for using other build cache types

### DIFF
--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
@@ -53,7 +53,8 @@ final class SystemPropertyOverrides {
         });
 
         // null check required to avoid creating a remote build cache instance when none was already present in the build
-        if (buildCache.getRemote() != null) {
+        // We need to ensure that this is the HttpBuildCache and not another build cache type like AWS S3.
+        if (buildCache.getRemote() != null && buildCache.getRemote() instanceof HttpBuildCache) {
             buildCache.remote(HttpBuildCache.class, remote -> {
                 sysProperty(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setUrl(appendPathAndTrailingSlash(remote.getUrl(), shard)));
                 sysProperty(REMOTE_CACHE_URL, providers).ifPresent(remote::setUrl);

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/SystemPropertyOverrides.java
@@ -52,9 +52,9 @@ final class SystemPropertyOverrides {
             booleanSysProperty(LOCAL_CACHE_PUSH, providers).ifPresent(local::setPush);
         });
 
-        // null check required to avoid creating a remote build cache instance when none was already present in the build
         // We need to ensure that this is the HttpBuildCache and not another build cache type like AWS S3.
-        if (buildCache.getRemote() != null && buildCache.getRemote() instanceof HttpBuildCache) {
+        // We don't configure or add a build cache configuration if none is already present.
+        if (buildCache.getRemote() instanceof HttpBuildCache) {
             buildCache.remote(HttpBuildCache.class, remote -> {
                 sysProperty(REMOTE_CACHE_SHARD, providers).ifPresent(shard -> remote.setUrl(appendPathAndTrailingSlash(remote.getUrl(), shard)));
                 sysProperty(REMOTE_CACHE_URL, providers).ifPresent(remote::setUrl);


### PR DESCRIPTION
When using a different build cache type the CCUD plugin would replace it with an HttpBuildCache. This checks the type to avoid replacement.
