### PR TITLE
Add GoCD support to the CCUD Gradle plugin and CCUD Maven extension

### DIFF
--- a/common-custom-user-data-gradle-plugin/CHANGELOG.md
+++ b/common-custom-user-data-gradle-plugin/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-
+- Detect GoCD CI and add respective custom CI tag, values and links
 
 ## [1.6.1] - 2021-11-23
 - Enable the ability to override various Gradle Enterprise configuration settings via environment variables (in addition to system properties)

--- a/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-gradle-plugin/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -12,6 +12,7 @@ import java.util.Properties;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static com.gradle.Utils.appendIfMissing;
 import static com.gradle.Utils.execAndCheckSuccess;
@@ -188,10 +189,34 @@ final class CustomBuildScanEnhancements {
             envVariable("BITRISE_BUILD_NUMBER").ifPresent(value ->
                 buildScan.value("CI build number", value));
         }
+
+        if (isGoCD()) {
+            Optional<String> pipelineName = envVariable("GO_PIPELINE_NAME");
+            Optional<String> pipelineNumber = envVariable("GO_PIPELINE_COUNTER");
+            Optional<String> stageName = envVariable("GO_STAGE_NAME");
+            Optional<String> stageNumber = envVariable("GO_STAGE_COUNTER");
+            Optional<String> jobName = envVariable("GO_JOB_NAME");
+            Optional<String> goServerUrl = envVariable("GO_SERVER_URL");
+            if (Stream.of(pipelineName, pipelineNumber, stageName, stageNumber, jobName, goServerUrl).allMatch(Optional::isPresent)) {
+                //noinspection OptionalGetWithoutIsPresent
+                String buildUrl = String.format("%s/tab/build/detail/%s/%s/%s/%s/%s",
+                    goServerUrl.get(), pipelineName.get(),
+                    pipelineNumber.get(), stageName.get(), stageNumber.get(), jobName.get());
+                buildScan.link("GoCD build", buildUrl);
+            } else if (goServerUrl.isPresent()) {
+                buildScan.link("GoCD", goServerUrl.get());
+            }
+            pipelineName.ifPresent(value ->
+                addCustomValueAndSearchLink("CI pipeline", value));
+            jobName.ifPresent(value ->
+                addCustomValueAndSearchLink("CI job", value));
+            stageName.ifPresent(value ->
+                addCustomValueAndSearchLink("CI stage", value));
+        }
     }
 
     private boolean isCi() {
-        return isGenericCI() || isJenkins() || isHudson() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis() || isBitrise();
+        return isGenericCI() || isJenkins() || isHudson() || isTeamCity() || isCircleCI() || isBamboo() || isGitHubActions() || isGitLab() || isTravis() || isBitrise() || isGoCD();
     }
 
     private boolean isGenericCI() {
@@ -232,6 +257,10 @@ final class CustomBuildScanEnhancements {
 
     private boolean isBitrise() {
         return envVariable("BITRISE_BUILD_URL").isPresent();
+    }
+
+    private boolean isGoCD() {
+        return envVariable("GO_SERVER_URL").isPresent();
     }
 
     private void captureGitMetadata() {

--- a/common-custom-user-data-maven-extension/CHANGELOG.md
+++ b/common-custom-user-data-maven-extension/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+- Detect GoCD CI and add respective custom CI tag, values and links
 
 ## [1.9] - 2021-11-11
 - Change the type of the `log` variable bound for custom Groovy scripts to `org.slf4j.Logger` (may affect custom Groovy scripts)


### PR DESCRIPTION
Adds:
- CI tag
- custom links for getting build scans with same "pipeline", "stage", "job"

Tested manually locally on a GoCD instance with both Gradle and Maven builds.