### PR TITLE
Validate Maven build caching samples

### DIFF
--- a/.github/workflows/build-caching-maven-samples.yml
+++ b/.github/workflows/build-caching-maven-samples.yml
@@ -1,0 +1,30 @@
+name: Maven extension smoke test
+
+on: [push]
+
+jobs:
+
+    verify-build-caching-maven-samples:
+        runs-on: ubuntu-latest
+        env:
+            working-directory: ./build-caching-maven-samples
+            LOG_MSG_EXTENSION_LOADED: "Build operation 'Gradle Enterprise mojo execution' completed"
+            LOG_MSG_EXECUTION_FAILED: "Error executing a GradleEnterpriseListener callback"
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+            - name: Set up JDK 11
+              uses: actions/setup-java@v2
+              with:
+                  java-version: '11'
+                  distribution: 'adopt'
+            - name: Setup Nodejs and npm
+              uses: actions/setup-node@v2
+              with:
+                  node-version: "14"
+            - name: Setup yarn
+              run: npm install -g yarn
+            - name: Setup yarn
+            - name: Run Maven verify
+              run: mvnw clean verify -Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -Dgradle.scan.disabled=true


### PR DESCRIPTION
Here is a GH workflow to validate our Maven build caching samples.

The current version is good enough to catch unknown fields in a Mojo.
An unhandled field is only logged as a warning in the console when a GE backend is effectively plugged. This is not supported at the moment.

Let me know @bigdaz if this is what you were thinking about.