### PR TITLE
Make Github actions more consistent between Maven and Gradle

### DIFF
--- a/.github/workflows/gradle-smoke-test.yml
+++ b/.github/workflows/gradle-smoke-test.yml
@@ -10,17 +10,17 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - project-dir: "common-custom-user-data-gradle-plugin"
+                    - build-dir: "common-gradle-enterprise-gradle-configuration"
                       sample-file: "../build-data-capturing-gradle-samples/capture-dependency-resolution/gradle-dependency-resolution.gradle"
-                    - project-dir: "common-custom-user-data-gradle-plugin"
+                    - build-dir: "common-gradle-enterprise-gradle-configuration"
                       sample-file: "../build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle"
-                    - project-dir: "common-custom-user-data-gradle-plugin"
+                    - build-dir: "common-gradle-enterprise-gradle-configuration"
                       sample-file: "../build-data-capturing-gradle-samples/capture-os-processes/gradle-os-processes.gradle"
-                    - project-dir: "common-custom-user-data-gradle-plugin"
+                    - build-dir: "common-gradle-enterprise-gradle-configuration"
                       sample-file: "../build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle"
-                    - project-dir: "common-custom-user-data-gradle-plugin"
+                    - build-dir: "common-gradle-enterprise-gradle-configuration"
                       sample-file: "../build-data-capturing-gradle-samples/capture-slow-workunit-executions/gradle-slow-task-executions.gradle"
-                    - project-dir: "common-custom-user-data-gradle-plugin"
+                    - build-dir: "common-gradle-enterprise-gradle-configuration"
                       sample-file: "../build-data-capturing-gradle-samples/capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle"
 
         steps:
@@ -31,16 +31,34 @@ jobs:
               with:
                   java-version: '11'
                   distribution: 'adopt'
-            - name: Build current snapshot of CCUD Gradle plugin
+            - name: Publish current snapshot of CCUD Gradle plugin to Maven local repository
               uses: gradle/gradle-build-action@v2
               with:
-                  arguments: build -x signArchives
-                  build-root-directory: ${{ matrix.project-dir }}
+                  arguments: publishToMavenLocal -x signArchives
+                  build-root-directory: common-custom-user-data-gradle-plugin
+            - name: Replace version in build configuration
+              run: |
+                  # fetching current snapshot version
+                  CURRENT_SNAPSHOT_VERSION=$(awk '/version =/ {print $3;exit;}' common-custom-user-data-gradle-plugin/build.gradle)
+                  PLUGIN_DECLARATION=$(echo "id \"com.gradle.common-custom-user-data-gradle-plugin\" version $CURRENT_SNAPSHOT_VERSION")
+                  # inplace replacement to use snapshot version
+                  sed -i "s/.*common-custom-user-data-gradle-plugin.*/$PLUGIN_DECLARATION/" ${{matrix.build-dir}}/settings.gradle
             - name: Prepare build directory
               run: |
-                echo "apply from: file(\"${{matrix.sample-file}}\")" >> ${{matrix.project-dir}}/build.gradle
+                # add maven local repository
+                echo -e "pluginManagement {\n
+                                 repositories {\n
+                                     mavenLocal()\n
+                                     maven {\n
+                                         url \"https://plugins.gradle.org/m2/\"\n
+                                     }\n
+                                 }\n
+                             }\n
+                             \n$(cat ${{matrix.build-dir}}/settings.gradle)" > ${{matrix.build-dir}}/settings.gradle
+                # apply sample file
+                echo "apply from: file(\"${{matrix.sample-file}}\")" >> ${{matrix.build-dir}}/build.gradle
             - name: Run Gradle build
               uses: gradle/gradle-build-action@v2
               with:
                   arguments: tasks
-                  build-root-directory: ${{matrix.project-dir}}
+                  build-root-directory: ${{matrix.build-dir}}

--- a/.github/workflows/gradle-smoke-test.yml
+++ b/.github/workflows/gradle-smoke-test.yml
@@ -31,7 +31,7 @@ jobs:
               with:
                   java-version: '11'
                   distribution: 'adopt'
-            - name: Publish current snapshot of CCUD Gradle plugin to Maven local repository
+            - name: Publish current snapshot of the CCUD Gradle plugin to local Maven repository
               uses: gradle/gradle-build-action@v2
               with:
                   arguments: publishToMavenLocal -x signArchives

--- a/.github/workflows/gradle-smoke-test.yml
+++ b/.github/workflows/gradle-smoke-test.yml
@@ -31,30 +31,13 @@ jobs:
               with:
                   java-version: '11'
                   distribution: 'adopt'
-            - name: Publish current snapshot of the CCUD Gradle plugin to local Maven repository
-              uses: gradle/gradle-build-action@v2
-              with:
-                  arguments: publishToMavenLocal -x signArchives
-                  build-root-directory: common-custom-user-data-gradle-plugin
-            - name: Replace version in build configuration
-              run: |
-                  # fetching current snapshot version
-                  CURRENT_SNAPSHOT_VERSION=$(awk '/version =/ {print $3;exit;}' common-custom-user-data-gradle-plugin/build.gradle)
-                  PLUGIN_DECLARATION=$(echo "id \"com.gradle.common-custom-user-data-gradle-plugin\" version $CURRENT_SNAPSHOT_VERSION")
-                  # inplace replacement to use snapshot version
-                  sed -i "s/.*common-custom-user-data-gradle-plugin.*/$PLUGIN_DECLARATION/" ${{matrix.build-dir}}/settings.gradle
             - name: Prepare build directory
               run: |
-                # add maven local repository
+                # include CCUD plugin
                 echo -e "pluginManagement {\n
-                                 repositories {\n
-                                     mavenLocal()\n
-                                     maven {\n
-                                         url \"https://plugins.gradle.org/m2/\"\n
-                                     }\n
-                                 }\n
-                             }\n
-                             \n$(cat ${{matrix.build-dir}}/settings.gradle)" > ${{matrix.build-dir}}/settings.gradle
+                            includeBuild \"../common-custom-user-data-gradle-plugin\"\n
+                         }\n
+                         $(cat ${{matrix.build-dir}}/settings.gradle)" > ${{matrix.build-dir}}/settings.gradle
                 # apply sample file
                 echo "apply from: file(\"${{matrix.sample-file}}\")" >> ${{matrix.build-dir}}/build.gradle
             - name: Run Gradle build

--- a/.github/workflows/gradle-smoke-test.yml
+++ b/.github/workflows/gradle-smoke-test.yml
@@ -3,34 +3,25 @@ name: Gradle smoke test
 on: [push]
 
 jobs:
-    build-ccud:
+
+    verify-gradle-samples:
         runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-            - name: Set up JDK 11
-              uses: actions/setup-java@v2
-              with:
-                  java-version: '11'
-                  distribution: 'adopt'
-            - name: Build CCUD Gradle plugin
-              uses: gradle/gradle-build-action@v2
-              with:
-                  arguments: build -x signArchives
-                  build-root-directory: common-custom-user-data-gradle-plugin
-
-    verify-samples:
-        runs-on: ubuntu-latest
         strategy:
             matrix:
                 include:
-                    - path-to-sample-build-file: "build-data-capturing-gradle-samples/capture-dependency-resolution/gradle-dependency-resolution.gradle"
-                    - path-to-sample-build-file: "build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle"
-                    - path-to-sample-build-file: "build-data-capturing-gradle-samples/capture-os-processes/gradle-os-processes.gradle"
-                    - path-to-sample-build-file: "build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle"
-                    - path-to-sample-build-file: "build-data-capturing-gradle-samples/capture-slow-workunit-executions/gradle-slow-task-executions.gradle"
-                    - path-to-sample-build-file: "build-data-capturing-gradle-samples/capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle"
+                    - project-dir: "common-custom-user-data-gradle-plugin"
+                      sample-file: "../build-data-capturing-gradle-samples/capture-dependency-resolution/gradle-dependency-resolution.gradle"
+                    - project-dir: "common-custom-user-data-gradle-plugin"
+                      sample-file: "../build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle"
+                    - project-dir: "common-custom-user-data-gradle-plugin"
+                      sample-file: "../build-data-capturing-gradle-samples/capture-os-processes/gradle-os-processes.gradle"
+                    - project-dir: "common-custom-user-data-gradle-plugin"
+                      sample-file: "../build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle"
+                    - project-dir: "common-custom-user-data-gradle-plugin"
+                      sample-file: "../build-data-capturing-gradle-samples/capture-slow-workunit-executions/gradle-slow-task-executions.gradle"
+                    - project-dir: "common-custom-user-data-gradle-plugin"
+                      sample-file: "../build-data-capturing-gradle-samples/capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle"
 
         steps:
             - name: Checkout
@@ -40,19 +31,16 @@ jobs:
               with:
                   java-version: '11'
                   distribution: 'adopt'
-            - name: Prepare sample builds
-              id: prepare
-              # Convert the sample script into a build that can be invoked by Gradle
-              # - Rename the script to build.gradle
-              # - Add a settings.gradle
+            - name: Build current snapshot of CCUD Gradle plugin
+              uses: gradle/gradle-build-action@v2
+              with:
+                  arguments: build -x signArchives
+                  build-root-directory: ${{ matrix.project-dir }}
+            - name: Prepare build directory
               run: |
-                PROJECT_DIR=$(dirname ${{matrix.path-to-sample-build-file}})
-                mv ${{matrix.path-to-sample-build-file}} $PROJECT_DIR/build.gradle
-                touch $PROJECT_DIR/settings.gradle
-                echo "::set-output name=project-dir::$PROJECT_DIR"
-            - name: Integrates sample scripts in order to validate them
+                echo "apply from: file(\"${{matrix.sample-file}}\")" >> ${{matrix.project-dir}}/build.gradle
+            - name: Run Gradle build
               uses: gradle/gradle-build-action@v2
               with:
                   arguments: tasks
-                  build-root-directory: ${{ steps.prepare.outputs.project-dir }}
-                  gradle-executable: common-custom-user-data-gradle-plugin/gradlew
+                  build-root-directory: ${{matrix.project-dir}}

--- a/.github/workflows/maven-smoke-test.yml
+++ b/.github/workflows/maven-smoke-test.yml
@@ -1,4 +1,4 @@
-name: Maven extension smoke test
+name: Maven smoke test
 
 on: [push]
 
@@ -13,18 +13,18 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - project-basedir: common-gradle-enterprise-maven-configuration
-                      relative-path-to-sample-build-file: "default"
-                    - project-basedir: common-custom-user-data-maven-extension
-                      relative-path-to-sample-build-file: "default"
-                    - project-basedir: common-custom-user-data-maven-extension
-                      relative-path-to-sample-build-file: "build-data-capturing-maven-samples/capture-os-processes/maven-os-processes.groovy"
-                    - project-basedir: common-custom-user-data-maven-extension
-                      relative-path-to-sample-build-file: "build-data-capturing-maven-samples/capture-quality-check-issues/maven-quality-check-issues.groovy"
-                    - project-basedir: common-custom-user-data-maven-extension
-                      relative-path-to-sample-build-file: "build-data-capturing-maven-samples/capture-top-level-project/maven-top-level-project.groovy"
-                    - project-basedir: common-custom-user-data-maven-extension
-                      relative-path-to-sample-build-file: "build-data-capturing-maven-samples/capture-profiles/maven-profiles.groovy"
+                    - project-dir: "common-gradle-enterprise-maven-configuration"
+                      sample-file: "default"
+                    - project-dir: "common-custom-user-data-maven-extension"
+                      sample-file: "default"
+                    - project-dir: "common-custom-user-data-maven-extension"
+                      sample-file: "build-data-capturing-maven-samples/capture-os-processes/maven-os-processes.groovy"
+                    - project-dir: "common-custom-user-data-maven-extension"
+                      sample-file: "build-data-capturing-maven-samples/capture-quality-check-issues/maven-quality-check-issues.groovy"
+                    - project-dir: "common-custom-user-data-maven-extension"
+                      sample-file: "build-data-capturing-maven-samples/capture-top-level-project/maven-top-level-project.groovy"
+                    - project-dir: "common-custom-user-data-maven-extension"
+                      sample-file: "build-data-capturing-maven-samples/capture-profiles/maven-profiles.groovy"
 
         steps:
             - name: Checkout
@@ -34,26 +34,26 @@ jobs:
               with:
                   java-version: '11'
                   distribution: 'adopt'
-            - name: Install current version of CCUD Maven extension
+            - name: Build current snapshot of CCUD Maven extension
               run: |
                   mvn -f common-custom-user-data-maven-extension/pom.xml install -Dgradle.scan.disabled=true
-            - name: Use current version of CCUD Maven extension in extension
+            - name: Replace version in build configuration
               run: |
                   sudo apt-get install -y xmlstarlet
                   # fetching current project version
                   CURRENT_VERSION=$(mvn -f common-custom-user-data-maven-extension/pom.xml -Dexec.executable='echo' -Dexec.args='${project.version}' -Dgradle.scan.disabled=true exec:exec -q)
                   # inplace replacement of the snippet version (latest release) with current version (snapshot)
-                  xmlstarlet edit --inplace --update "//extensions/extension[artifactId='common-custom-user-data-maven-extension']/version" --value $CURRENT_VERSION  ${{ matrix.project-basedir }}/.mvn/extensions.xml
-            - name: Copy current sample
+                  xmlstarlet edit --inplace --update "//extensions/extension[artifactId='common-custom-user-data-maven-extension']/version" --value $CURRENT_VERSION  ${{ matrix.project-dir }}/.mvn/extensions.xml
+            - name: Prepare build directory
               run: |
                   # default uses the original gradle-enterprise-custom-user-data.groovy
-                  if [[ ${{ matrix.relative-path-to-sample-build-file }} != "default" ]]; then
-                      cp ${{ matrix.relative-path-to-sample-build-file }} ${{ matrix.project-basedir }}/.mvn/gradle-enterprise-custom-user-data.groovy
+                  if [[ ${{ matrix.sample-file }} != "default" ]]; then
+                      cp ${{ matrix.sample-file }} ${{ matrix.project-dir }}/.mvn/gradle-enterprise-custom-user-data.groovy
                   fi
-            - name: Run Maven build using CCUD extension
+            - name: Run Maven build
               run: |
                   echo 'MAVEN_OUTPUT<<EOF' >> $GITHUB_ENV
-                  mvn -f ${{ matrix.project-basedir }}/pom.xml -X --batch-mode clean validate -Dgradle.scan.disabled=true >> $GITHUB_ENV
+                  mvn -f ${{ matrix.project-dir }}/pom.xml -X --batch-mode clean validate -Dgradle.scan.disabled=true >> $GITHUB_ENV
                   echo 'EOF' >> $GITHUB_ENV
             - name: Validate extension loaded
               run: |

--- a/.github/workflows/maven-smoke-test.yml
+++ b/.github/workflows/maven-smoke-test.yml
@@ -34,7 +34,7 @@ jobs:
               with:
                   java-version: '11'
                   distribution: 'adopt'
-            - name: Publish current snapshot of CCUD Maven extension to Maven local repository
+            - name: Publish current snapshot of the CCUD Maven extension to local Maven repository
               run: |
                   mvn -f common-custom-user-data-maven-extension/pom.xml install -Dgradle.scan.disabled=true
             - name: Replace version in build configuration

--- a/.github/workflows/maven-smoke-test.yml
+++ b/.github/workflows/maven-smoke-test.yml
@@ -13,17 +13,17 @@ jobs:
         strategy:
             matrix:
                 include:
-                    - project-dir: "common-gradle-enterprise-maven-configuration"
+                    - build-dir: "common-gradle-enterprise-maven-configuration"
                       sample-file: "default"
-                    - project-dir: "common-custom-user-data-maven-extension"
+                    - build-dir: "common-custom-user-data-maven-extension"
                       sample-file: "default"
-                    - project-dir: "common-custom-user-data-maven-extension"
+                    - build-dir: "common-custom-user-data-maven-extension"
                       sample-file: "build-data-capturing-maven-samples/capture-os-processes/maven-os-processes.groovy"
-                    - project-dir: "common-custom-user-data-maven-extension"
+                    - build-dir: "common-custom-user-data-maven-extension"
                       sample-file: "build-data-capturing-maven-samples/capture-quality-check-issues/maven-quality-check-issues.groovy"
-                    - project-dir: "common-custom-user-data-maven-extension"
+                    - build-dir: "common-custom-user-data-maven-extension"
                       sample-file: "build-data-capturing-maven-samples/capture-top-level-project/maven-top-level-project.groovy"
-                    - project-dir: "common-custom-user-data-maven-extension"
+                    - build-dir: "common-custom-user-data-maven-extension"
                       sample-file: "build-data-capturing-maven-samples/capture-profiles/maven-profiles.groovy"
 
         steps:
@@ -34,26 +34,26 @@ jobs:
               with:
                   java-version: '11'
                   distribution: 'adopt'
-            - name: Build current snapshot of CCUD Maven extension
+            - name: Publish current snapshot of CCUD Maven extension to Maven local repository
               run: |
                   mvn -f common-custom-user-data-maven-extension/pom.xml install -Dgradle.scan.disabled=true
             - name: Replace version in build configuration
               run: |
                   sudo apt-get install -y xmlstarlet
-                  # fetching current project version
-                  CURRENT_VERSION=$(mvn -f common-custom-user-data-maven-extension/pom.xml -Dexec.executable='echo' -Dexec.args='${project.version}' -Dgradle.scan.disabled=true exec:exec -q)
-                  # inplace replacement of the snippet version (latest release) with current version (snapshot)
-                  xmlstarlet edit --inplace --update "//extensions/extension[artifactId='common-custom-user-data-maven-extension']/version" --value $CURRENT_VERSION  ${{ matrix.project-dir }}/.mvn/extensions.xml
+                  # fetching current snapshot version
+                  CURRENT_SNAPSHOT_VERSION=$(mvn -f common-custom-user-data-maven-extension/pom.xml -Dexec.executable='echo' -Dexec.args='${project.version}' -Dgradle.scan.disabled=true exec:exec -q)
+                  # inplace replacement to use snapshot version
+                  xmlstarlet edit --inplace --update "//extensions/extension[artifactId='common-custom-user-data-maven-extension']/version" --value $CURRENT_SNAPSHOT_VERSION  ${{ matrix.build-dir }}/.mvn/extensions.xml
             - name: Prepare build directory
               run: |
                   # default uses the original gradle-enterprise-custom-user-data.groovy
                   if [[ ${{ matrix.sample-file }} != "default" ]]; then
-                      cp ${{ matrix.sample-file }} ${{ matrix.project-dir }}/.mvn/gradle-enterprise-custom-user-data.groovy
+                      cp ${{ matrix.sample-file }} ${{ matrix.build-dir }}/.mvn/gradle-enterprise-custom-user-data.groovy
                   fi
             - name: Run Maven build
               run: |
                   echo 'MAVEN_OUTPUT<<EOF' >> $GITHUB_ENV
-                  mvn -f ${{ matrix.project-dir }}/pom.xml -X --batch-mode clean validate -Dgradle.scan.disabled=true >> $GITHUB_ENV
+                  mvn -f ${{ matrix.build-dir }}/pom.xml -X --batch-mode clean validate -Dgradle.scan.disabled=true >> $GITHUB_ENV
                   echo 'EOF' >> $GITHUB_ENV
             - name: Validate extension loaded
               run: |


### PR DESCRIPTION
Objective is to have Gradle and Maven GH actions more consistent.
There are still some differences as configuration and verification steps are slightly different for Maven and Gradle.