### PR TITLE
Tag build when various skip tests property are set to true or empty

### DIFF
--- a/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
+++ b/common-custom-user-data-maven-extension/src/main/java/com/gradle/CustomBuildScanEnhancements.java
@@ -42,6 +42,21 @@ final class CustomBuildScanEnhancements {
         captureCiOrLocal();
         captureCiMetadata();
         captureGitMetadata();
+        captureSkipTests();
+    }
+
+    private void captureSkipTests() {
+        customValueWhenTrueOrEmpty("skipTests");
+        customValueWhenTrueOrEmpty("maven.test.skip");
+        customValueWhenTrueOrEmpty("skipITs");
+    }
+
+    private void customValueWhenTrueOrEmpty(String property) {
+        projectProperty(property).ifPresent(value -> {
+            if (Boolean.TRUE.toString().equals(value) || value.isEmpty()) {
+                buildScan.value("maven.switches", property);
+            }
+        });
     }
 
     private void captureOs() {


### PR DESCRIPTION
Set specific tag(s) regarding only system properties `skipTests`, `maven.test.skip`, `skipITs`. Note that tests can be skipped with surefire/failsafe specific configuration, this is not taken into account as it can be specific per project. Here's a recap of various cases:

```        
        label                                                         | system prop               | expectedTag
        --------------------------------------------------------------------------------------------------------
        "skip all tests (no value)"                                   | "-DskipTests"             | "skipTests"
        "skip all tests"                                              | "-DskipTests=true"        | "skipTests"
        "do not skip all tests"                                       | "-DskipTests=false"       | _
        "do not skip all tests (unknown value)"                       | "-DskipTests=foo"         | _
        "skip all integration tests (no value)"                       | "-DskipITs"               | "skipITs"
        "skip all integration tests"                                  | "-DskipITs=true"          | "skipITs"
        "do not skip all integration tests"                           | "-DskipITs=false"         | _
        "do not skip all integration tests (unknown value)"           | "-DskipITs=foo"           | _
        "skip compiling and running all tests (no value)"             | "-Dmaven.test.skip"       | "skipTests"
        "skip compiling and running all tests"                        | "-Dmaven.test.skip=true"  | "skipTests"
        "do not skip compiling and running all tests"                 | "-Dmaven.test.skip=false" | _
        "do not skip compiling and running all tests (unknown value)" | "-Dmaven.test.skip=foo"   | _
```

https://github.com/gradle/ge/issues/11242