### PR TITLE
Add "Set up Gradle" step to GHActions workflows

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -31,12 +31,12 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
       - name: Inject data capture script into Gradle build
         run: |
           # apply sample file
           echo "apply from: file(\"../build-data-capturing-gradle-samples/${{matrix.sample-file}}\")" >> common-gradle-enterprise-gradle-configuration/build.gradle
       - name: Run Gradle build
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: tasks
-          build-root-directory: 'common-gradle-enterprise-gradle-configuration'
+        working-directory: common-gradle-enterprise-gradle-configuration
+        run: ./gradlew tasks


### PR DESCRIPTION
Separating the setup of the Gradle build tool from actual build invocation
is more idiomatic to GH Actions in general, and provides a clearer separation
of responsibilities.