### PR TITLE
Add Kotlin data capturing samples

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Run Gradle build with Groovy scripts
         working-directory: common-gradle-enterprise-gradle-configuration
         run: ./gradlew tasks   
+      - name: Inject data capture Kotlin script into Gradle build
+        run: |
+          # apply sample file
+          echo "apply from: file(\"../build-data-capturing-gradle-samples/${{matrix.sample-file}}.kts\")" >> common-gradle-enterprise-gradle-configuration/build.gradle
       - name: Run Gradle build with Kotlin scripts
         working-directory: common-gradle-enterprise-gradle-configuration
         run: ./gradlew tasks -c settings.gradle.kts

--- a/build-data-capturing-gradle-samples/capture-dependency-resolution/gradle-dependency-resolution.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-dependency-resolution/gradle-dependency-resolution.gradle.kts
@@ -1,0 +1,30 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+import org.gradle.api.internal.artifacts.configurations.ConfigurationInternal
+import org.gradle.api.internal.artifacts.configurations.ResolutionStrategyInternal
+
+/**
+ * This Gradle script captures any dependency configurations that are resolved early to build the task graph,
+ * and adds these as custom values.
+ * This should be applied to the root project:
+ * <code> apply from: file('gradle-dependency-resolution.gradle.kts') </code>
+ */
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        buildFinished {
+            val confs = mutableListOf<String>()
+            allprojects {
+                configurations.forEach {
+                    if (it is ConfigurationInternal) {
+                        if (it.getState() == Configuration.State.RESOLVED && (it.getResolutionStrategy() as ResolutionStrategyInternal).resolveGraphToDetermineTaskDependencies()) {
+                            confs.add(it.getIdentityPath().toString())
+                        }
+                    }
+                }
+            }
+
+            confs.forEach {
+                value("Configuration resolved for task graph calculation", it)
+            }
+        }
+    }
+}

--- a/build-data-capturing-gradle-samples/capture-ge-plugin-version/gradle-ge-plugin-version.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-ge-plugin-version/gradle-ge-plugin-version.gradle.kts
@@ -1,0 +1,15 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+
+/**
+ * This Groovy script captures the Gradle Enterprise Gradle plugin version as a custom value.
+ *
+ * <code> apply from: file('gradle-ge-plugin-version.gradle.kts') </code>
+ */
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        val url = GradleEnterpriseExtension::class.java.classLoader.getResource("com.gradle.scan.plugin.internal.meta.buildAgentVersion.txt")
+        val buildAgentVersion = url.readText()
+        value("GE Gradle plugin version", buildAgentVersion)
+    }
+}
+

--- a/build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle.kts
@@ -1,0 +1,97 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+import com.gradle.scan.plugin.BuildScanExtension
+import groovy.json.JsonBuilder
+import groovy.json.JsonSlurper
+
+import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
+
+/**
+ * This Gradle script captures the <i>Git diff</i> in a GitHub gist,
+ * and references the gist via a custom link.
+ * This should be applied to the root project:
+ * <code> apply from: file('gradle-git-diffs.gradle.kts') </code>
+ *
+ * In order for the gist to be created successfully, you must specify the Gradle property `gistToken` where
+ * the value is a Github access token that has gist permission on the given Github repo.
+ *
+ * See https://docs.github.com/en/free-pro-team@latest/rest/reference/gists#create-a-gist for reference.
+ */
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        background {
+            captureGitDiffInGist(buildScan)
+        }
+    }
+}
+
+fun captureGitDiffInGist(buildScan: BuildScanExtension): Unit {
+    val isCapturingScan = !gradle.startParameter.isOffline && !gradle.startParameter.isContinuous
+    if (!isCapturingScan) {
+        gradle.rootProject.logger.warn("Build is offline or continuous. Will not publish gist.")
+        return
+    }
+
+    val hasGistCredentials = gradle.rootProject.hasProperty("gistToken")
+    if (!hasGistCredentials) {
+        gradle.rootProject.logger.warn("User has not set 'gistToken'. Cannot publish gist.")
+        return
+    }
+
+    val diff = execAndGetStdout("git", "diff")
+    if (!diff.isNullOrEmpty()) {
+        try {
+            val baseUrl = java.net.URL("https://api.github.com/gists")
+            val credentials = gradle.rootProject.findProperty("gistToken") as String
+            val auth = "token " + credentials
+
+            val connection = baseUrl.openConnection() as java.net.HttpURLConnection
+            connection.apply {
+                // request
+                setRequestProperty("Authorization", auth)
+                setRequestProperty("Accept", "application/vnd.github+json")
+                requestMethod = "POST"
+                doOutput = true
+                outputStream.bufferedWriter().use { writer ->
+                    jsonRequest(writer, diff, gradle.rootProject)
+                }
+
+                // response
+                val url = JsonSlurper().parse(content as java.io.InputStream).withGroovyBuilder { getProperty("html_url") }
+                buildScan.link("Git diff", url as String)
+            }
+            gradle.rootProject.logger.info("Successfully published gist.")
+        } catch (ex: Exception) {
+            gradle.rootProject.logger.warn("Unable to publish gist", ex)
+        }
+    }
+}
+
+// this method must be static, otherwise Gradle will interpret `files` as Project.files() and this won't work
+fun jsonRequest(writer: java.io.Writer, diff: String, project: Project): Unit {
+    val json = groovy.json.JsonOutput.toJson(mapOf(
+        "description" to "Git diff for ${project.name}",
+        "public" to false,
+        "files" to mapOf("${project.name}.diff" to mapOf("content" to diff))))
+    writer.write(json)
+}
+
+fun execAndGetStdout(vararg args: String): String {
+    val process = ProcessBuilder(*args)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+    try {
+            val finished = process.waitFor(10, TimeUnit.SECONDS)
+            val standardText = process.inputStream.bufferedReader().readText()
+            val ignore = process.errorStream.bufferedReader().readText()
+
+            return if (finished && process.exitValue() == 0) trimAtEnd(standardText) else return ""
+    } finally {
+        process.destroyForcibly()
+    }
+}
+
+fun trimAtEnd(str: String): String {
+    return ("x" + str).trim().substring(1)
+}

--- a/build-data-capturing-gradle-samples/capture-os-processes/gradle-os-processes.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-os-processes/gradle-os-processes.gradle.kts
@@ -1,0 +1,43 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+import com.gradle.scan.plugin.BuildScanExtension
+import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
+
+/**
+ * This Gradle script captures the OS processes as reported by the OS 'ps' command,
+ * and adds these as a custom value.
+ * This should be applied to the root project:
+ * <code> apply from: file('gradle-os-processes.gradle.kts') </code>
+ */
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        background {
+            captureOsProcesses(buildScan)
+        }
+    }
+}
+
+fun captureOsProcesses(buildScan: BuildScanExtension): Unit {
+    val psOutput = execAndGetStdout("ps", "-o pid,ppid,time,command")
+    buildScan.value("OS processes", psOutput)
+}
+
+fun execAndGetStdout(vararg args: String): String {
+    val process = ProcessBuilder(*args)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+    try {
+            val finished = process.waitFor(10, TimeUnit.SECONDS)
+            val standardText = process.inputStream.bufferedReader().readText()
+            val ignore = process.errorStream.bufferedReader().readText()
+
+            return if (finished && process.exitValue() == 0) trimAtEnd(standardText) else return ""
+    } finally {
+        process.destroyForcibly()
+    }
+}
+
+fun trimAtEnd(str: String): String {
+    return ("x" + str).trim().substring(1)
+}

--- a/build-data-capturing-gradle-samples/capture-processor-arch/gradle-processor-arch.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-processor-arch/gradle-processor-arch.gradle.kts
@@ -1,0 +1,68 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+import com.gradle.scan.plugin.BuildScanExtension
+import java.nio.charset.Charset
+import java.util.concurrent.TimeUnit
+
+/**
+ * This Gradle script captures the processor architecture
+ * and adds these as a custom value.
+ * This should be applied to the root project:
+ * <code> apply from: file('gradle-processor-arch.gradle.kts') </code>
+ */
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        background {
+            captureProcessorArch(buildScan)
+        }
+    }
+}
+
+fun captureProcessorArch(buildScan: BuildScanExtension): Unit {
+  val osName = System.getProperty("os.name")
+  buildScan.value("os.name", osName)
+
+  val osArch = System.getProperty("os.arch")
+  buildScan.value("os.arch", osArch)
+
+  if (isDarwin(osName)) {
+    if (isTranslatedByRosetta()) {
+      buildScan.tag("M1-translated")
+    } else if (isM1()) {
+      buildScan.tag("M1")
+    }
+  }
+}
+
+fun isDarwin(osName: String): Boolean {
+  return osName.contains("OS X") || osName.startsWith("Darwin")
+}
+
+fun isM1(): Boolean {
+  return execAndGetStdout("uname", "-p") == "arm"
+}
+
+// On Apple silicon, a universal binary may run either natively or as a translated binary
+// https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#Determine-Whether-Your-App-Is-Running-as-a-Translated-Binary
+fun isTranslatedByRosetta(): Boolean {
+  return execAndGetStdout("sysctl", "sysctl.proc_translated") == "sysctl.proc_translated: 1"
+}
+
+fun execAndGetStdout(vararg args: String): String {
+    val process = ProcessBuilder(*args)
+            .redirectOutput(ProcessBuilder.Redirect.PIPE)
+            .redirectError(ProcessBuilder.Redirect.PIPE)
+            .start()
+    try {
+            val finished = process.waitFor(10, TimeUnit.SECONDS)
+            val standardText = process.inputStream.bufferedReader().readText()
+            val ignore = process.errorStream.bufferedReader().readText()
+
+            return if (finished && process.exitValue() == 0) trimAtEnd(standardText) else return ""
+    } finally {
+        process.destroyForcibly()
+    }
+}
+
+fun trimAtEnd(str: String): String {
+    return ("x" + str).trim().substring(1)
+}

--- a/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle.kts
@@ -1,0 +1,130 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+import com.gradle.scan.plugin.BuildScanExtension
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.NodeChildren
+import groovy.xml.slurpersupport.NodeChild
+import groovy.xml.slurpersupport.GPathResult
+
+/**
+ * This Gradle script captures issues found by reporting tasks,
+ * and adds these as custom values.
+ * This should be applied to the root project:
+ * <code> apply from: file('gradle-quality-check-issues.gradle.kts') </code>
+ */
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        gradle.taskGraph.beforeTask {
+            if (ReportingTask.isSupported(this) && this is Reporting<*>) {
+                val reportTask = this as Reporting<ReportContainer<*>>
+                reportTask.reports.withGroovyBuilder { "xml" { setProperty("enabled", true) } }
+            } else if (ReportingTask.SPOTBUGS.isTask(this)) {
+                this.withGroovyBuilder {
+                    val reports = getProperty("reports")
+                    val xml = (reports as NamedDomainObjectContainer<*>).create("xml") {
+                        enabled = true
+                    }
+                }
+            }
+        }
+
+        gradle.taskGraph.afterTask {
+            if (ReportingTask.isSupported(this)) {
+                val reportFile = reportFromTask(this)
+                if (reportFile.exists()) {
+                    val report = XmlSlurper().parse(reportFile)
+                    var valueName = ""
+                    var errors = mutableListOf<String>()
+
+                    if (ReportingTask.CHECKSTYLE.isTask(this)) {
+                        valueName = "Verification Checkstyle"
+                        val files = report.getProperty("file") as NodeChildren
+                        files.forEach { f ->
+                            val file = f as NodeChild
+                            val filePath = project.rootProject.relativePath(file.attributes()["name"])
+                            val checkErrors = file.getProperty("error") as NodeChildren
+                            checkErrors.forEach { e ->
+                                val error = e as NodeChild
+                                errors.add("${filePath}:${error.attributes()["line"]}:${error.attributes()["column"]} \u2192 ${error.attributes()["message"]}")
+                            }
+                        }
+                    } else if (ReportingTask.CODENARC.isTask(this)) {
+                        valueName = "Verification CodeNarc"
+                        val packages = report.getProperty("Package") as NodeChildren
+                        packages.forEach { p ->
+                            val proj = report.getProperty("Project") as NodeChildren
+                            val sourceDirectoryNode = proj.getProperty("SourceDirectory") as NodeChildren
+                            val sourceDirectory = appendIfMissing(sourceDirectoryNode.text() as String, "/")
+                            val files = (p as NodeChild).getProperty("File") as NodeChildren
+                            files.forEach { f ->
+                                val file = f as NodeChild
+                                val filePath =
+                                    project.rootProject.relativePath(sourceDirectory + file.attributes()["name"])
+                                (file.getProperty("Violation") as NodeChildren).forEach { v ->
+                                    val violation = v as NodeChild
+                                    errors.add("${filePath}:${violation.attributes()["lineNumber"]} \u2192 ${violation.attributes()["ruleName"]}")
+                                }
+                            }
+                        }
+                    } else if (ReportingTask.SPOTBUGS.isTask(this)) {
+                        valueName = "Verification SpotBugs"
+                        val bugs = report.getProperty("BugInstance") as NodeChildren
+                        bugs.forEach { b ->
+                            val bug = b as NodeChild
+                            val type = bug.attributes()["type"]
+                            val error = bug.breadthFirst().asSequence().filter { l ->
+                                val line = l as NodeChild
+                                l.name() == "SourceLine"
+                            }.sortedBy { l ->
+                                (l as NodeChild).parent().name()
+                            }.first() as NodeChild
+                            val startLine = error.attributes()["start"]
+                            val endLine = error.attributes()["end"]
+                            val lineNumber = if (endLine == startLine) startLine else "${startLine}-${endLine}"
+                            val className = error.attributes()["classname"]
+                            errors.add("${className}:${lineNumber} \u2192 ${type}")
+                        }
+                    }
+                    errors.forEach { e -> buildScan.value(valueName, e) }
+                }
+            }
+        }
+    }
+}
+
+fun reportFromTask(task: Task): File {
+    if (task is Reporting<*>) {
+        val task = task as Reporting<ReportContainer<*>>
+        return (task.reports.withGroovyBuilder { "xml" { getProperty("destination") } } as Report).getOutputLocation().get().asFile as File
+    } else if (ReportingTask.SPOTBUGS.isTask(task)) {
+        val reports = task.withGroovyBuilder { getProperty("reports") as NamedDomainObjectContainer<*> }
+        val report = (reports.named("XML") as NamedDomainObjectProvider).get() as SingleFileReport
+        return report.getOutputLocation().get().asFile
+    } else {
+        throw IllegalStateException("Unsupported report task: " + task)
+    }
+}
+
+fun appendIfMissing(str: String, suffix: String): String {
+    return if (str.endsWith(suffix)) str else str + suffix
+}
+
+enum class SpotBugsParent {
+    BugInstance, Method, Class
+}
+
+enum class ReportingTask(val className: String) {
+
+    CHECKSTYLE("org.gradle.api.plugins.quality.Checkstyle"),
+    CODENARC("org.gradle.api.plugins.quality.CodeNarc"),
+    SPOTBUGS("com.github.spotbugs.snom.SpotBugsTask");
+
+    fun isTask(task: Task): Boolean {
+        return task::class.java.name.contains(className)
+    }
+
+    companion object {
+        fun isSupported(task: Task): Boolean {
+            return values().any { it.isTask(task) }
+        }
+    }
+}

--- a/build-data-capturing-gradle-samples/capture-slow-workunit-executions/gradle-slow-task-executions.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-slow-workunit-executions/gradle-slow-task-executions.gradle.kts
@@ -1,0 +1,29 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+import com.gradle.scan.plugin.BuildScanExtension
+
+/**
+ * This Gradle script captures all tasks of a given type taking longer to execute than a certain threshold,
+ * and adds these as custom values.
+ * This should be applied to the root project:
+ * <code> apply from: file('gradle-slow-task-executions.gradle.kts') </code>
+ */
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        val THRESHOLD_MILLIS = 15 * 60 * 1000 // 15 min
+
+        allprojects {
+            tasks.withType<JavaCompile> {
+                var start = 0L
+                doFirst {
+                    start = System.currentTimeMillis()
+                }
+                doLast {
+                    val duration = System.currentTimeMillis() - start
+                    if (duration > THRESHOLD_MILLIS) {
+                        value("Slow task", identityPath.toString())
+                    }
+                }
+            }
+        }
+    }
+}

--- a/build-data-capturing-gradle-samples/capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle.kts
@@ -1,0 +1,43 @@
+import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
+import com.gradle.scan.plugin.BuildScanExtension
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
+
+/**
+ * This Gradle script captures the system properties available to each Test task, hashes the properties' values,
+ * and adds these as custom values.
+ * This should be applied to the root project since it configures all projects:
+ * <code> apply from: file('gradle-test-execution-system-properties.gradle.kts') </code>
+ */
+val MESSAGE_DIGEST = MessageDigest.getInstance("SHA-256")
+
+project.extensions.configure<GradleEnterpriseExtension>() {
+    buildScan {
+        allprojects {
+            tasks.withType<Test> {
+                doFirst {
+                    systemProperties.forEach { (k, v) -> value("${identityPath}#sysProps-${k}", hash(v)) }
+                }
+            }
+        }
+    }
+}
+
+fun hash(value: Any?): String? {
+    if (value == null) {
+        return null
+    } else {
+        val str = java.lang.String.valueOf(value)
+        val encodedHash = MESSAGE_DIGEST.digest(str.toByteArray())
+        val hexString = StringBuilder()
+        for (i in 0 until (encodedHash.size / 4)) {
+            val hex = java.lang.Integer.toHexString(0xff and encodedHash[i].toInt())
+            if (hex.length == 1) {
+                hexString.append("0")
+            }
+            hexString.append(hex)
+        }
+        hexString.append("...")
+        return hexString.toString()
+    }
+}


### PR DESCRIPTION
This adds:
- a sample settings.gradle.kts
- sample Kotlin scripts to capture data, equivalent to the Groovy ones

Notes:
- the `gradle-quality-check-issues.gradle.kts` is quite complicated, the FindBugs part has been removed since replaced by SpotBugs. Here how it looks for:
    - [Checkstyle](https://ge.solutions-team.gradle.com/s/ngfq2kc36xe7o/custom-values)
    - [SpotBugs](https://ge.solutions-team.gradle.com/s/65xd4tnpogawg/custom-values)
    - [CodeNarc](https://ge.solutions-team.gradle.com/s/hrmovn57p4kcq/custom-values)
- only the `gradle-dependency-resolution.gradle.kts` has not been manually tested (not sure how to create such build)
- this is not an idiomatic Kotlin port, probably could be simplified here and there