### PR TITLE
Add settings.gradle.kts sample

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -39,6 +39,9 @@ jobs:
         run: |
           # apply sample file
           echo "apply from: file(\"../build-data-capturing-gradle-samples/${{matrix.sample-file}}\")" >> common-gradle-enterprise-gradle-configuration/build.gradle
-      - name: Run Gradle build
+      - name: Run Gradle build with Groovy scripts
         working-directory: common-gradle-enterprise-gradle-configuration
-        run: ./gradlew tasks
+        run: ./gradlew tasks   
+      - name: Run Gradle build with Kotlin scripts
+        working-directory: common-gradle-enterprise-gradle-configuration
+        run: ./gradlew tasks -c settings.gradle.kts

--- a/common-gradle-enterprise-gradle-configuration/settings.gradle.kts
+++ b/common-gradle-enterprise-gradle-configuration/settings.gradle.kts
@@ -1,0 +1,36 @@
+plugins {
+    id("com.gradle.enterprise") version("3.11.1")
+    id("com.gradle.common-custom-user-data-gradle-plugin") version("1.8")
+}
+
+val isCI = !System.getenv("CI").isNullOrEmpty() // adjust to your CI provider
+
+gradleEnterprise {
+    server = "https://enterprise-samples.gradle.com" // adjust to your GE server
+    allowUntrustedServer = false // ensure a trusted certificate is configured
+
+    buildScan {
+        capture { isTaskInputFiles = true }
+        isUploadInBackground = !isCI
+        publishAlways()
+    }
+}
+
+buildCache {
+    local {
+        isEnabled = true
+    }
+
+    remote<HttpBuildCache> {
+        url = uri("https://enterprise-samples.gradle.com/cache/") // adjust to your GE server, and note the trailing slash
+        isAllowUntrustedServer = false // ensure a trusted certificate is configured
+        credentials {
+            username = System.getenv("GRADLE_ENTERPRISE_CACHE_USERNAME")
+            password = System.getenv("GRADLE_ENTERPRISE_CACHE_PASSWORD")
+        }
+        isEnabled = true
+        isPush = isCI
+    }
+}
+
+rootProject.name = "common-gradle-enterprise-gradle-configuration" // adjust to your project


### PR DESCRIPTION
This PR simply adds a Kotlin script `settings.gradle.kts` sample. Notes:
- by default `gradle <task>` will take the `settings.gradle`, that's why the GH action validating this will run `gradle <task> -c settings.gradle.kts` to force using this one
- another PR will modernize both Gradle and Kotlin settings samples (using builtin cache connector...)