### PR TITLE
Use Gradle Enterprise build cache connector in config samples

### DIFF
--- a/common-gradle-enterprise-gradle-configuration/settings.gradle
+++ b/common-gradle-enterprise-gradle-configuration/settings.gradle
@@ -21,8 +21,15 @@ buildCache {
         enabled = true
     }
 
-    remote(HttpBuildCache) {
-        url = 'https://enterprise-samples.gradle.com/cache/' // adjust to your GE server, and note the trailing slash
+    // Use the Gradle Enterprise connector's access key based authentication
+    remote(gradleEnterprise.buildCache) {
+        enabled = true
+        push = isCI
+    }
+
+    // Use Gradle's built-in HTTP connector
+    /* remote(HttpBuildCache) {
+        url = 'https://enterprise-samples.gradle.com/cache/' // adjust to your build cache node, and note the trailing slash
         allowUntrustedServer = false // ensure a trusted certificate is configured
         credentials { creds ->
             creds.username = System.getenv('GRADLE_ENTERPRISE_CACHE_USERNAME')
@@ -30,7 +37,7 @@ buildCache {
         }
         enabled = true
         push = isCI
-    }
+    } */
 }
 
 rootProject.name = 'common-gradle-enterprise-gradle-configuration' // adjust to your project

--- a/common-gradle-enterprise-gradle-configuration/settings.gradle
+++ b/common-gradle-enterprise-gradle-configuration/settings.gradle
@@ -27,8 +27,9 @@ buildCache {
         push = isCI
     }
 
-    // Use Gradle's built-in HTTP connector
-    /* remote(HttpBuildCache) {
+    // Use Gradle's built-in access credentials
+    /**
+    remote(HttpBuildCache) {
         url = 'https://enterprise-samples.gradle.com/cache/' // adjust to your build cache node, and note the trailing slash
         allowUntrustedServer = false // ensure a trusted certificate is configured
         credentials { creds ->
@@ -37,7 +38,8 @@ buildCache {
         }
         enabled = true
         push = isCI
-    } */
+    }
+    */
 }
 
 rootProject.name = 'common-gradle-enterprise-gradle-configuration' // adjust to your project

--- a/common-gradle-enterprise-gradle-configuration/settings.gradle.kts
+++ b/common-gradle-enterprise-gradle-configuration/settings.gradle.kts
@@ -27,8 +27,9 @@ buildCache {
         isPush = isCI
     }
 
-    // Use Gradle's built-in HTTP connector
-    /* remote(HttpBuildCache::class) {
+    // Use Gradle's built-in access credentials
+    /**
+    remote(HttpBuildCache::class) {
         url = uri("https://enterprise-samples.gradle.com/cache/") // adjust to your GE server, and note the trailing slash
         isAllowUntrustedServer = false // ensure a trusted certificate is configured
         credentials {
@@ -37,7 +38,8 @@ buildCache {
         }
         isEnabled = true
         isPush = isCI
-    } */
+    }
+    */
 }
 
 rootProject.name = "common-gradle-enterprise-gradle-configuration" // adjust to your project

--- a/common-gradle-enterprise-gradle-configuration/settings.gradle.kts
+++ b/common-gradle-enterprise-gradle-configuration/settings.gradle.kts
@@ -21,7 +21,14 @@ buildCache {
         isEnabled = true
     }
 
-    remote<HttpBuildCache> {
+    // Use the Gradle Enterprise connector's access key based authentication
+    remote(gradleEnterprise.buildCache) {
+        isEnabled = true
+        isPush = isCI
+    }
+
+    // Use Gradle's built-in HTTP connector
+    /* remote(HttpBuildCache::class) {
         url = uri("https://enterprise-samples.gradle.com/cache/") // adjust to your GE server, and note the trailing slash
         isAllowUntrustedServer = false // ensure a trusted certificate is configured
         credentials {
@@ -30,7 +37,7 @@ buildCache {
         }
         isEnabled = true
         isPush = isCI
-    }
+    } */
 }
 
 rootProject.name = "common-gradle-enterprise-gradle-configuration" // adjust to your project

--- a/common-gradle-enterprise-maven-configuration/.mvn/gradle-enterprise.xml
+++ b/common-gradle-enterprise-maven-configuration/.mvn/gradle-enterprise.xml
@@ -32,16 +32,19 @@
       <enabled>true</enabled>
     </local>
     <remote>
+     <!-- Use the Gradle Enterprise connector's access key based authentication -->
+      <enabled>true</enabled>
+      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled> <!-- adjust to your CI provider -->
+
+      <!-- Use build cache node credentials
       <server>
-        <url>https://enterprise-samples.gradle.com/cache/</url> <!-- adjust to your GE server, and note the trailing slash -->
-        <allowUntrusted>false</allowUntrusted> <!-- ensure a trusted certificate is configured -->
+        <url>https://enterprise-samples.gradle.com/cache/</url> 
+        <allowUntrusted>false</allowUntrusted>
         <credentials>
           <username>${env.GRADLE_ENTERPRISE_CACHE_USERNAME}</username>
           <password>${env.GRADLE_ENTERPRISE_CACHE_PASSWORD}</password>
         </credentials>
-      </server>
-      <enabled>true</enabled>
-      <storeEnabled>#{isTrue(env['CI'])}</storeEnabled> <!-- adjust to your CI provider -->
+      </server> -->
     </remote>
   </buildCache>
 </gradleEnterprise>


### PR DESCRIPTION
After Gradle Enterprise latest releases (GE 2022.3, GE plugin 3.11.1 and GE extension 1.15) we don't need to configure credentails for the GE builtin cache node.

Note that using the "old" way of configuring the build cache connector with credentials is still provided as comments.