### PR TITLE
Include maxMetaspaceSize in recommended JVM args

### DIFF
--- a/common-gradle-enterprise-gradle-configuration/gradle.properties
+++ b/common-gradle-enterprise-gradle-configuration/gradle.properties
@@ -5,4 +5,5 @@ org.gradle.caching=true
 org.gradle.parallel=true
 
 # adjust the locale values to your project's needs and the memory settings to the requirements of your build
-org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 -Xmx512M
+# due to https://github.com/gradle/gradle/issues/19750 be sure to include both `-Xmx` and `-XX:MaxMetaspaceSize` settings
+org.gradle.jvmargs=-Duser.language=en -Duser.country=US -Dfile.encoding=UTF-8 -Xmx512m -XX:MaxMetaspaceSize=256m


### PR DESCRIPTION
Due to https://github.com/gradle/gradle/issues/19750, it is important to include both `-Xmx` and `-XX:MaxMetaspaceSize` settings when setting a value for `org.gradle.jvmargs`.