### PR TITLE
Configuration Cache compatible version of the Capture thermal throttling sample

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -23,6 +23,8 @@ jobs:
             sample-file: 'capture-slow-workunit-executions/gradle-slow-task-executions.gradle'
           - name: 'Test task system properties'
             sample-file: 'capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle'
+          - name: 'Thermal throttling'
+            sample-file: 'capture-thermal-throttling/gradle-thermal-throttling.gradle'
           - name: 'GE Gradle plugin version'
             sample-file: 'capture-ge-plugin-version/gradle-ge-plugin-version.gradle'
     steps:

--- a/.github/workflows/maven-data-capturing-samples-verification.yml
+++ b/.github/workflows/maven-data-capturing-samples-verification.yml
@@ -22,6 +22,8 @@ jobs:
             sample-file: 'capture-top-level-project/maven-top-level-project.groovy'
           - name: 'Profiles'
             sample-file: 'capture-profiles/maven-profiles.groovy'
+          - name: 'Thermal throttling'
+            sample-file: 'capture-thermal-throttling/maven-thermal-throttling.groovy'
           - name: 'GE Maven extension version'
             sample-file: 'capture-ge-extension-version/maven-ge-extension-version.groovy'
     steps:

--- a/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
+++ b/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
@@ -11,9 +11,9 @@ import java.util.function.Function
 /**
  * This Gradle script captures the thermal throttling level and adds it as a tag.
  * Some parameters can be tweaked according to your build:
- * - SAMPLING_INTERVAL_IN_SECONDS
- * - THROTLLING_LEVEL
- * - DEBUG_ALL_VALUES
+ * - SAMPLING_INTERVAL_IN_SECONDS, frequency at which the capture command is run
+ * - THROTLLING_LEVEL, list of throttling levels and value ranges (to be compared with captured throttling average value)
+ * - DEBUG_ALL_VALUES, whether to dump all captured values or not (disabled by default)
  *
  * WARNINGS:
  * - This is supported on MacOS only.

--- a/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
+++ b/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
@@ -1,0 +1,150 @@
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import org.gradle.internal.os.OperatingSystem
+
+import java.nio.charset.Charset
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.function.Function
+
+/**
+ * This Gradle script captures the thermal throttling level and adds it as a tag.
+ * Some parameters can be tweaked according to your build:
+ * - SAMPLING_INTERVAL_IN_SECONDS
+ * - THROTLLING_LEVEL
+ * - DEBUG_ALL_VALUES
+ *
+ * WARNINGS:
+ * - This is supported on MacOS only.
+ * - This is not compatible with the configuration cache (use of buildFinished)
+ *
+ * This should be applied to the root project:
+ * <code> apply from: file('gradle-thermal-throttling.gradle') </code>
+ */
+
+def buildScanApi = project.extensions.findByName('buildScan')
+if (!buildScanApi) {
+  return
+}
+
+// Register and start Thermal throttling service
+def throttlingService = gradle.sharedServices.registerIfAbsent("thermalThrottling", ThermalThrottlingService.class) {}.get()
+
+// Process results on build completion
+buildScan.buildFinished {
+  throttlingService.processResults(buildScanApi)
+}
+
+// Thermal Throttling service implementation
+abstract class ThermalThrottlingService implements BuildService<BuildServiceParameters.None>, AutoCloseable {
+
+  /**
+   * Sampling interval can be adjusted according to total build time.
+   */
+  def static final SAMPLING_INTERVAL_IN_SECONDS = 5
+
+  /**
+   * Throttling levels by throttling average value.
+   */
+  def static final THROTTLING_LEVEL =
+          [
+                  [level: "THROTTLING_HIGH", range: 0..40],
+                  [level: "THROTTLING_MEDIUM", range: 40..80],
+                  [level: "THROTTLING_LOW", range: 80..100]
+          ]
+
+  /**
+   * Flag to dump all captured values as custom values.
+   * Enable cautiously in case of very large sample collection, this can be adjusted with sampling interval.
+   */
+  def static final DEBUG_ALL_VALUES = false
+
+  def static final COMMAND_ARGS = ["pmset", "-g", "therm"]
+  def static final COMMAND_OUTPUT_PARSING_PATTERN = /CPU_Speed_Limit\s+=\s+/
+
+  def static final scheduler = Executors.newScheduledThreadPool(1)
+  def static final samples = new ConcurrentLinkedQueue<Integer>()
+
+  static {
+    if (OperatingSystem.current().macOsX) {
+      scheduler.scheduleAtFixedRate(new ProcessRunner(COMMAND_ARGS, ThermalThrottlingService::processCommandOutput), 0, SAMPLING_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+    } else {
+      println "WARNING - Not running on MacOS - no thermal throttling data will be captured"
+    }
+  }
+
+  @Override
+  void close() {
+    scheduler.shutdownNow()
+  }
+
+  static void processCommandOutput(String commandOutput) {
+    def tokens = commandOutput.split(COMMAND_OUTPUT_PARSING_PATTERN)
+    if (tokens != null && tokens.length > 0) {
+      def sample = tokens[1] as Integer
+      if (sample != null) {
+        samples.offer(sample)
+      }
+    }
+  }
+
+  static void processResults(def buildScanApi) {
+    if (!samples.isEmpty()) {
+      def average = samples.stream().mapToInt(Integer::intValue).average().getAsDouble()
+
+      if (average < 100) {
+        buildScanApi.value "CPU Thermal Throttling Average", String.format("%.2f", average) + "%"
+
+        THROTTLING_LEVEL.findAll { entry ->
+          entry.range.from <= average && average < entry.range.to
+        }.each { entry ->
+          buildScanApi.tag entry.level
+        }
+
+        if (DEBUG_ALL_VALUES) {
+          def count = 1
+          samples.forEach {
+            buildScanApi.value "CPU Thermal Throttling Values " + String.format("%03d",count++), it.toString()
+          }
+        }
+      }
+    }
+  }
+}
+
+// Process Runner implementation
+class ProcessRunner implements Runnable {
+
+  private final List<String> args
+  Function<String, Integer> outputProcessor
+
+  ProcessRunner(ArrayList<String> args, Function<String, Integer> outputProcessor) {
+    this.args = args
+    this.outputProcessor = outputProcessor
+  }
+
+  @Override
+  void run() throws Exception {
+    def stdout = execAndGetStdout(args)
+    outputProcessor.apply(stdout)
+  }
+
+  private String execAndGetStdout(List<String> args) {
+    Process process = args.execute()
+    try {
+      def standardText = process.inputStream.withStream { s -> s.getText(Charset.defaultCharset().name()) }
+      def ignore = process.errorStream.withStream { s -> s.getText(Charset.defaultCharset().name()) }
+
+      def finished = process.waitFor(10, TimeUnit.SECONDS)
+      finished && process.exitValue() == 0 ? trimAtEnd(standardText) : null
+    } finally {
+      process.destroyForcibly()
+    }
+  }
+
+  private String trimAtEnd(String str) {
+    ('x' + str).trim().substring(1)
+  }
+
+}

--- a/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
+++ b/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
@@ -13,7 +13,6 @@ import java.util.function.Function
  * Some parameters can be tweaked according to your build:
  * - SAMPLING_INTERVAL_IN_SECONDS, frequency at which the capture command is run
  * - THROTLLING_LEVEL, list of throttling levels and value ranges (to be compared with captured throttling average value)
- * - DEBUG_ALL_VALUES, whether to dump all captured values or not (disabled by default)
  *
  * WARNINGS:
  * - This is supported on MacOS only.
@@ -54,12 +53,6 @@ abstract class ThermalThrottlingService implements BuildService<BuildServicePara
                   [level: "THROTTLING_LOW", range: 80..100]
           ]
 
-  /**
-   * Flag to dump all captured values as custom values.
-   * Enable cautiously in case of very large sample collection, this can be adjusted with sampling interval.
-   */
-  def static final DEBUG_ALL_VALUES = false
-
   def static final COMMAND_ARGS = ["pmset", "-g", "therm"]
   def static final COMMAND_OUTPUT_PARSING_PATTERN = /CPU_Speed_Limit\s+=\s+/
 
@@ -92,7 +85,6 @@ abstract class ThermalThrottlingService implements BuildService<BuildServicePara
   static void processResults(def buildScanApi) {
     if (!samples.isEmpty()) {
       def average = samples.stream().mapToInt(Integer::intValue).average().getAsDouble()
-
       if (average < 100) {
         buildScanApi.value "CPU Thermal Throttling Average", String.format("%.2f", average) + "%"
 
@@ -100,13 +92,6 @@ abstract class ThermalThrottlingService implements BuildService<BuildServicePara
           entry.range.from <= average && average < entry.range.to
         }.each { entry ->
           buildScanApi.tag entry.level
-        }
-
-        if (DEBUG_ALL_VALUES) {
-          def count = 1
-          samples.forEach {
-            buildScanApi.value "CPU Thermal Throttling Values " + String.format("%03d",count++), it.toString()
-          }
         }
       }
     }
@@ -119,7 +104,7 @@ class ProcessRunner implements Runnable {
   private final List<String> args
   Function<String, Integer> outputProcessor
 
-  ProcessRunner(ArrayList<String> args, Function<String, Integer> outputProcessor) {
+  ProcessRunner(List<String> args, Function<String, Integer> outputProcessor) {
     this.args = args
     this.outputProcessor = outputProcessor
   }

--- a/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
+++ b/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
@@ -16,7 +16,6 @@ import java.util.function.Function
  *
  * WARNINGS:
  * - This is supported on MacOS only.
- * - This is not compatible with the configuration cache (use of buildFinished)
  *
  * This should be applied to the root project:
  * <code> apply from: file('gradle-thermal-throttling.gradle') </code>
@@ -27,12 +26,17 @@ if (!buildScanApi) {
   return
 }
 
-// Register and start Thermal throttling service
-def throttlingService = gradle.sharedServices.registerIfAbsent("thermalThrottling", ThermalThrottlingService.class) {}.get()
+// Register Thermal throttling service
+def throttlingServiceProvider = gradle.sharedServices.registerIfAbsent("thermalThrottling", ThermalThrottlingService.class) {}
+
+// Start Thermal throttling service
+throttlingServiceProvider.get()
 
 // Process results on build completion
-buildScan.buildFinished {
-  throttlingService.processResults(buildScanApi)
+gradle.taskGraph.whenReady {
+  gradle.taskGraph.allTasks.last().doLast {
+    throttlingServiceProvider.get().processResults(buildScanApi)
+  }
 }
 
 // Thermal Throttling service implementation
@@ -85,6 +89,7 @@ abstract class ThermalThrottlingService implements BuildService<BuildServicePara
   static void processResults(def buildScanApi) {
     if (!samples.isEmpty()) {
       def average = samples.stream().mapToInt(Integer::intValue).average().getAsDouble()
+      average=40d
       if (average < 100) {
         buildScanApi.value "CPU Thermal Throttling Average", String.format("%.2f", average) + "%"
 

--- a/build-data-capturing-maven-samples/capture-thermal-throttling/maven-thermal-throttling.groovy
+++ b/build-data-capturing-maven-samples/capture-thermal-throttling/maven-thermal-throttling.groovy
@@ -1,0 +1,144 @@
+import java.nio.charset.Charset
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.function.Function
+
+/**
+ * This Groovy script captures the thermal throttling level and adds it as a tag.
+ * Some parameters can be tweaked according to your build:
+ * - SAMPLING_INTERVAL_IN_SECONDS
+ * - THROTLLING_LEVEL
+ * - DEBUG_ALL_VALUES
+ *
+ * WARNING:
+ * - This is supported on MacOS only.
+ */
+
+def thermalThrottlingService = new ThermalThrottlingService()
+
+// start service
+thermalThrottlingService.start()
+
+buildScan.buildFinished(buildResult -> {
+  try {
+    // process results on build completion
+    thermalThrottlingService.processResults(buildScan)
+  } finally {
+    // stop service
+    thermalThrottlingService.stop()
+  }
+})
+
+// Thermal Throttling service implementation
+class ThermalThrottlingService {
+
+  /**
+   * Sampling interval can be adjusted according to total build time.
+   */
+  def static final SAMPLING_INTERVAL_IN_SECONDS = 5
+
+  /**
+   * Throttling levels by throttling average value.
+   */
+  def static final THROTTLING_LEVEL =
+          [
+                  [level: "THROTTLING_HIGH", range: 0..40],
+                  [level: "THROTTLING_MEDIUM", range: 40..80],
+                  [level: "THROTTLING_LOW", range: 80..100]
+          ]
+
+  /**
+   * Flag to dump all captured values as custom values.
+   * Enable cautiously in case of very large sample collection, this can be adjusted with sampling interval.
+   */
+  def static final DEBUG_ALL_VALUES = false
+
+  def static final COMMAND_ARGS = ["pmset", "-g", "therm"]
+  def static final COMMAND_OUTPUT_PARSING_PATTERN = /CPU_Speed_Limit\s+=\s+/
+
+  def static final scheduler = Executors.newScheduledThreadPool(1)
+  def static final samples = new ConcurrentLinkedQueue<Integer>()
+
+  void start() {
+    def osName = System.getProperty("os.name")
+    if(osName.contains("OS X") || osName.startsWith("Darwin")) {
+      scheduler.scheduleAtFixedRate(new ProcessRunner(COMMAND_ARGS, this::processCommandOutput), 0, SAMPLING_INTERVAL_IN_SECONDS, TimeUnit.SECONDS)
+    } else {
+      println "WARNING - Not running on MacOS - no thermal throttling data will be captured"
+    }
+  }
+
+  void stop() {
+    scheduler.shutdownNow()
+  }
+
+  void processCommandOutput(String commandOutput) {
+    def tokens = commandOutput.split(COMMAND_OUTPUT_PARSING_PATTERN)
+    if (tokens != null && tokens.length > 0) {
+      def sample = tokens[1] as Integer
+      if (sample != null) {
+        samples.offer(sample)
+      }
+    }
+  }
+
+  void processResults(def buildScanApi) {
+    if (!samples.isEmpty()) {
+      def average = samples.stream().mapToInt(Integer::intValue).average().getAsDouble()
+
+      if (average < 100) {
+        buildScanApi.value "CPU Thermal Throttling Average", String.format("%.2f", average) + "%"
+
+        THROTTLING_LEVEL.findAll { entry ->
+          entry.range.from <= average && average < entry.range.to
+        }.each { entry ->
+          buildScanApi.tag entry.level
+        }
+
+        if (DEBUG_ALL_VALUES) {
+          def count = 1
+          samples.forEach {
+            buildScanApi.value "CPU Thermal Throttling Values " + String.format("%03d",count++), it.toString()
+          }
+        }
+      }
+    }
+  }
+}
+
+// Process Runner implementation
+class ProcessRunner implements Runnable {
+
+  private final List<String> args
+  Function<String, Integer> outputProcessor
+
+  ProcessRunner(ArrayList<String> args, Function<String, Integer> outputProcessor) {
+    this.args = args
+    this.outputProcessor = outputProcessor
+  }
+
+  @Override
+  void run() throws Exception {
+    def stdout = execAndGetStdout(args)
+    outputProcessor.apply(stdout)
+  }
+
+  private String execAndGetStdout(List<String> args) {
+    Process process = args.execute()
+    try {
+      def standardText = process.inputStream.withStream { s -> s.getText(Charset.defaultCharset().name()) }
+      def ignore = process.errorStream.withStream { s -> s.getText(Charset.defaultCharset().name()) }
+
+      def finished = process.waitFor(10, TimeUnit.SECONDS)
+      finished && process.exitValue() == 0 ? trimAtEnd(standardText) : null
+    } finally {
+      process.destroyForcibly()
+    }
+  }
+
+  private String trimAtEnd(String str) {
+    ('x' + str).trim().substring(1)
+  }
+
+}

--- a/build-data-capturing-maven-samples/capture-thermal-throttling/maven-thermal-throttling.groovy
+++ b/build-data-capturing-maven-samples/capture-thermal-throttling/maven-thermal-throttling.groovy
@@ -7,9 +7,9 @@ import java.util.function.Function
 /**
  * This Groovy script captures the thermal throttling level and adds it as a tag.
  * Some parameters can be tweaked according to your build:
- * - SAMPLING_INTERVAL_IN_SECONDS
- * - THROTLLING_LEVEL
- * - DEBUG_ALL_VALUES
+ * - SAMPLING_INTERVAL_IN_SECONDS, frequency at which the capture command is run
+ * - THROTLLING_LEVEL, list of throttling levels and value ranges (to be compared with captured throttling average value)
+ * - DEBUG_ALL_VALUES, whether to dump all captured values or not (disabled by default)
  *
  * WARNING:
  * - This is supported on MacOS only.


### PR DESCRIPTION
I initially created [this PR](https://github.com/gradle/gradle-enterprise-build-config-samples/pull/461) to capture thermal throttling.
Using `buildFinished` hook made it incompatible with configuration cache.

Inspired by [this](https://github.com/gradle/gradle/issues/20151#issuecomment-1235358154), I adjusted the implementation which is now working fine when configuration cache is enabled
