### PR TITLE
Add test task PTS compatibility capturing

### DIFF
--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -1,0 +1,78 @@
+import java.nio.charset.StandardCharsets
+import java.util.Optional
+import java.util.jar.JarFile
+import java.util.stream.Stream
+import java.util.stream.Collectors
+import groovy.transform.Field
+
+/**
+ * This Gradle script captures Predictive Test Selection and Test Distribution compatibility for each Test task, 
+ * adding a flag as custom value.
+ * This should be applied to the root project since it configures all projects:
+ * <code> apply from: file('gradle-test-pts-support.gradle') </code>
+ */
+
+def buildScanApi = project.extensions.findByName('buildScan')
+if (!buildScanApi) {
+    return
+}
+
+@Field
+final def supportedEngines = [
+    'org.junit.support.testng.engine.TestNGTestEngine' : 'testng',
+    'org.junit.jupiter.engine.JupiterTestEngine' : 'junit-jupiter', 
+    'org.junit.vintage.engine.VintageTestEngine' : 'junit-vintage', 
+    'org.spockframework.runtime.SpockEngine' : 'spock',
+    'net.jqwik.engine.JqwikTestEngine' : 'jqwik',
+    'com.tngtech.archunit.junit.ArchUnitTestEngine' : 'archunit',
+    'co.helmethair.scalatest.ScalatestEngine' : 'scalatest'
+    ]
+
+allprojects {
+    tasks.withType(Test).configureEach { t ->
+        doFirst {
+            if (t.getTestFramework().getClass().getName() == 'org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework') {
+                def engines = testEngines(t) 
+                buildScanApi.value("${t.identityPath}#engines", "${engines}")
+                if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
+                    buildScanApi.value("${t.identityPath}#pts", 'SUPPORTED')
+                } else {
+                    buildScanApi.value("${t.identityPath}#pts", 'ENGINES_NOT_ALL_SUPPORTED')
+                }
+            } else {
+                buildScanApi.value("${t.identityPath}#pts", 'NO_JUNIT_PLATFORM')
+            }
+        }
+    }
+}
+
+Set<String> testEngines(Test t) {
+    try {
+        Stream<String> engines = t.classpath.files.stream()
+                .filter { f -> f.name.endsWith('.jar') }
+                .filter { f -> supportedEngines.values().stream().anyMatch { e -> f.name.contains(e) } }
+                .map { f -> findTestEngine(f) }
+                .flatMap { o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty() }
+
+        // We take into account included/excluded engines (but only known ones)
+        def included = t.options.includeEngines
+        if (included) {
+            engines = engines.filter { e -> supportedEngines.get(e) == null || included.contains(supportedEngines.get(e)) }
+        }
+        def excluded = t.options.excludeEngines  
+        if (excluded) {
+            engines = engines.filter { e -> supportedEngines.get(e) == null || !excluded.contains(supportedEngines.get(e)) }
+        }                  
+        return engines.collect(Collectors.toSet())
+    } catch (Exception e) {
+        gradle.rootProject.logger.warn("Could not detect test engines", e)
+    }
+    return false
+}
+
+Optional<String> findTestEngine(File jar) {
+    try (def jarFile = new JarFile(jar)) {
+        return Optional.ofNullable(jarFile.getEntry('META-INF/services/org.junit.platform.engine.TestEngine'))
+                .map { e -> jarFile.getInputStream(e).withCloseable { it.getText(StandardCharsets.UTF_8.name()).trim() } }
+    }
+}


### PR DESCRIPTION
For each test task, the script will:
- check if framework is a direct instance of `org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework`
- try to extract test engines from the classpath jar's and compare them to a known list of supported engines. It will also filter according to `includeEngines` or `excludeEngines` potentially set on the test task
- set a custom value accordingly