### PR TITLE
Upgrade Github actions/checkout to v3

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -29,7 +29,7 @@ jobs:
             sample-file: 'capture-ge-plugin-version/gradle-ge-plugin-version.gradle'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate
         uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -10,7 +10,7 @@ jobs:
       GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/maven-data-capturing-samples-verification.yml
+++ b/.github/workflows/maven-data-capturing-samples-verification.yml
@@ -28,7 +28,7 @@ jobs:
             sample-file: 'capture-ge-extension-version/maven-ge-extension-version.groovy'
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/.github/workflows/shell-script-validation.yml
+++ b/.github/workflows/shell-script-validation.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Validate
         uses: luizm/action-sh-checker@v0.1.12
         env:


### PR DESCRIPTION
Deprecation warnings appear when running actions/checkout@v2, this is fixed when upgrading to actions/checkout@v3