### PR TITLE
Add missing verification for PTS support data capture, sort matrix

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -11,6 +11,8 @@ jobs:
         include:
           - name: 'Dependency resolution'
             sample-file: 'capture-dependency-resolution/gradle-dependency-resolution.gradle'
+          - name: 'GE Gradle plugin version'
+            sample-file: 'capture-ge-plugin-version/gradle-ge-plugin-version.gradle'
           - name: 'Git diffs'
             sample-file: 'capture-git-diffs/gradle-git-diffs.gradle'
           - name: 'OS processes'
@@ -23,10 +25,10 @@ jobs:
             sample-file: 'capture-slow-workunit-executions/gradle-slow-task-executions.gradle'
           - name: 'Test task system properties'
             sample-file: 'capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle'
+          - name: 'Test PTS support'
+            sample-file: 'capture-test-pts-support/gradle-test-pts-support.gradle'
           - name: 'Thermal throttling'
             sample-file: 'capture-thermal-throttling/gradle-thermal-throttling.gradle'
-          - name: 'GE Gradle plugin version'
-            sample-file: 'capture-ge-plugin-version/gradle-ge-plugin-version.gradle'
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/maven-data-capturing-samples-verification.yml
+++ b/.github/workflows/maven-data-capturing-samples-verification.yml
@@ -12,20 +12,20 @@ jobs:
     strategy:
       matrix:
         include:
+          - name: 'GE Maven extension version'
+            sample-file: 'capture-ge-extension-version/maven-ge-extension-version.groovy'
           - name: 'OS processes'
             sample-file: 'capture-os-processes/maven-os-processes.groovy'
           - name: 'Processor arch'
             sample-file: 'capture-processor-arch/maven-processor-arch.groovy'
-          - name: 'Quality checks'
-            sample-file: 'capture-quality-check-issues/maven-quality-check-issues.groovy'
-          - name: 'Top-level project'
-            sample-file: 'capture-top-level-project/maven-top-level-project.groovy'
           - name: 'Profiles'
             sample-file: 'capture-profiles/maven-profiles.groovy'
+          - name: 'Quality checks'
+            sample-file: 'capture-quality-check-issues/maven-quality-check-issues.groovy'
           - name: 'Thermal throttling'
             sample-file: 'capture-thermal-throttling/maven-thermal-throttling.groovy'
-          - name: 'GE Maven extension version'
-            sample-file: 'capture-ge-extension-version/maven-ge-extension-version.groovy'
+          - name: 'Top-level project'
+            sample-file: 'capture-top-level-project/maven-top-level-project.groovy'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds the PTS support data capture sample to the verification matrix.

I also took this opportunity to sort the matrix by `sample-file` so that its order is consistent with how it is displayed when viewing on the file system.