### PR TITLE
Update quality check samples to be Gradle 8 compatible

### DIFF
--- a/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
+++ b/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
@@ -15,7 +15,7 @@ gradle.taskGraph.beforeTask { task ->
         return
     }
 
-    task.configure { t -> t.reports.xml.enabled = true }
+    task.configure { t -> t.reports.xml.required = true }
 }
 
 gradle.taskGraph.afterTask { task, TaskState state ->
@@ -23,7 +23,7 @@ gradle.taskGraph.afterTask { task, TaskState state ->
         return
     }
 
-    def reportFile = task.reports.xml.destination as File
+    def reportFile = task.reports.xml.outputLocation.get().asFile
     if (!reportFile.exists()) {
         return
     }


### PR DESCRIPTION
The `enabled` and `destination` properties have been replaced by `required` and `outputLocation`, respectively.