### PR TITLE
Override `protocArtifact` to version with M1 support

### DIFF
--- a/build-caching-maven-samples/protobuf-project/pom.xml
+++ b/build-caching-maven-samples/protobuf-project/pom.xml
@@ -32,6 +32,8 @@
             </goals>
             <configuration>
               <outputDirectory>target/generated-sources/protobuf</outputDirectory>
+
+              <!-- The plugin's bundled version of protoc does not support M1 processors, so use a version that does -->
               <protocArtifact>com.google.protobuf:protoc:3.17.3</protocArtifact>
             </configuration>
           </execution>

--- a/build-caching-maven-samples/protobuf-project/pom.xml
+++ b/build-caching-maven-samples/protobuf-project/pom.xml
@@ -32,6 +32,7 @@
             </goals>
             <configuration>
               <outputDirectory>target/generated-sources/protobuf</outputDirectory>
+              <protocArtifact>com.google.protobuf:protoc:3.17.3</protocArtifact>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
While working on #504, I ran into an issue building `build-caching-maven-samples` locally due to the `protoc` version bundled with `com.github.os72:protoc-jar-maven-plugin:3.11.4` not having M1 support.

![image](https://user-images.githubusercontent.com/5797900/203419317-65de9455-7ca3-421f-90ac-10a5efbc0f90.png)

Unfortunately, this appears to be the latest version of the plugin. However, from [the plugin's README](https://github.com/os72/protoc-jar-maven-plugin/blob/master/README.md?plain=1#L99), you can configure the plugin to use a non-bundled version of `protoc` by specifying the `protocArtifact` configuration property. This allows us to use a newer version of `protoc` which has M1 support.

I'm not sure if this is something we actually want to do, but it was easy enough to open a PR for so I figured I'd open one.

Note: The version I have configured is not the latest. It's just the first version with M1 support. 

Something else to consider is defining the `protoc` version as a property and referencing it for both `protocArtifact` and for the `protoc` project dependency. 