### PR TITLE
Fix workflow for Kotlin DSL capturing samples

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -40,18 +40,20 @@ jobs:
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
       - name: Inject data capture script into Gradle build using Groovy DSL
+        working-directory: common-gradle-enterprise-gradle-configuration-groovy
         run: |
           # apply sample file
-          echo "apply from: file(\"../build-data-capturing-gradle-samples/${{matrix.sample-file}}\")" >> common-gradle-enterprise-gradle-configuration-groovy/build.gradle
+          echo "apply from: file(\"../build-data-capturing-gradle-samples/${{matrix.sample-file}}\")" >> build.gradle
       - name: Run Gradle build using Groovy DSL
         working-directory: common-gradle-enterprise-gradle-configuration-groovy
         run: ./gradlew tasks -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
       - name: Inject data capture script into Gradle build using Kotlin DSL
+        working-directory: common-gradle-enterprise-gradle-configuration-kotlin
         run: |
           # apply sample file
-          echo "apply from: file(\"../build-data-capturing-gradle-samples/${{matrix.sample-file}}\")" >> common-gradle-enterprise-gradle-configuration-kotlin/build.gradle
+          echo "apply(from = \"../build-data-capturing-gradle-samples/${{matrix.sample-file}}\")" >> build.gradle.kts
       - name: Run Gradle build using Kotlin DSL
         working-directory: common-gradle-enterprise-gradle-configuration-kotlin
         run: ./gradlew tasks -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com


### PR DESCRIPTION
I noticed the new workflow to verify the capturing samples using the Kotlin DSL subproject was referencing a `build.gradle` file instead of `build.gradle.kts`. It was also using Groovy DSL (`apply from: ...`) instead of Kotlin DSL (`apply(from = ...)`) to apply the capturing script.

I also update the steps to use the `working-directory` property to make it consistent with the surrounding steps.