### PR TITLE
Add README for build data and capturing samples

### DIFF
--- a/build-data-capturing-gradle-samples/README.md
+++ b/build-data-capturing-gradle-samples/README.md
@@ -1,0 +1,97 @@
+# Build Data Capturing Gradle Samples
+
+## Overview
+
+This directory contains samples demonstrating various ways to extend and customize a Build Scan with extra data using 
+tags, links, and custom values.
+
+To learn more, see the Gradle Enterprise documentation
+on [Extending build scans](https://docs.gradle.com/enterprise/gradle-plugin/#extending_build_scans). 
+
+### Capture Dependency Resolution
+
+[//]: # (todo figure out what this sample is doing)
+
+### Capture GE Plugin Version
+
+_Demonstrates: Custom values_
+
+This sample demonstrates how to capture the Gradle Enterprise Gradle plugin version as a custom value. This can be used
+to identify projects using a certain version of the plugin within the Build Scan dashboard.
+
+### Capture Git Diffs
+
+_Demonstrates: Custom links_
+
+This sample creates a private GitHub gist containing the difference between the current working directory and the index.
+The URL of the gist is included as a custom link named `Git diff` at the top of the Build Scan.
+
+### Capture OS Processes
+
+_Demonstrates: Custom values_
+
+This sample captures the output of the `ps` command and adds it to the Build Scan as a custom value named
+`OS processes`.
+
+### Capture Processor Arch
+
+_Demonstrates: Custom values, Custom tags_
+
+This sample adds the operating system name and processor architecture as custom values and adds a tag to the Build Scan
+if the build was executed on an M1 processor.
+
+### Capture Quality Check Issues
+
+_Demonstrates: Custom values_
+
+This sample parses the XML reports of several common quality check plugins and includes the findings as custom values on
+the corresponding Build Scan.
+
+### Capture Slow Work-unit Executions
+
+_Demonstrates: Custom values_
+
+This sample adds a custom value to the Build Scan for each task that has an execution time greater than a specified 
+threshold.
+
+### Capture Test Execution System Properties
+
+_Demonstrates: Custom values_
+
+This sample adds the system properties of test tasks to the Build Scan. In order to not leak sensitive information, the
+value of the system property is hashed. This can be useful in Build Scan comparison as it helps identify any system 
+properties which differed between two builds.
+
+### Capture Test PTS Support
+
+_Demonstrates: Custom values_
+
+This sample adds a custom value
+showing [Test Distribution](https://gradle.com/gradle-enterprise-solutions/test-distribution/)
+and [Predictive Test Selection](https://gradle.com/gradle-enterprise-solutions/predictive-test-selection/) compatibility
+for each test task.
+
+### Capture Thermal Throttling
+
+_Demonstrates: Custom values, Custom tags_
+
+This sample adds a custom value for macOS builds that captures the average amount of thermal throttling that was 
+applied during the build, a technique where the CPU is throttled in an effort to reduce heat. It then applies a tag to 
+the Build Scan that maps the percentage to a "level of thermal throttling".
+
+## Usage
+
+The purpose of these samples is to demonstrate different ways to capture custom data and use it to customize a Build
+Scan. However, each sample has been written as
+a [script plugin](https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins), allowing any sample to be 
+used directly within a build.
+
+```groovy
+// build.gradle
+apply from: 'build-data-capturing-sample.gradle'
+```
+
+```kotlin
+// build.gradle.kts
+apply(from = "build-data-capturing-sample.gradle.kts")
+```

--- a/build-data-capturing-gradle-samples/README.md
+++ b/build-data-capturing-gradle-samples/README.md
@@ -22,11 +22,7 @@ This directory contains samples demonstrating various ways to extend and customi
 tags, links, and custom values.
 
 To learn more, see the Gradle Enterprise documentation
-on [Extending build scans](https://docs.gradle.com/enterprise/gradle-plugin/#extending_build_scans). 
-
-### Capture Dependency Resolution
-
-[//]: # (todo figure out what this sample is doing)
+on [Extending build scans](https://docs.gradle.com/enterprise/gradle-plugin/#extending_build_scans).
 
 ### Capture GE Plugin Version
 

--- a/build-data-capturing-gradle-samples/README.md
+++ b/build-data-capturing-gradle-samples/README.md
@@ -1,5 +1,21 @@
 # Build Data Capturing Gradle Samples
 
+## Usage
+
+Each sample has been written as
+a [script plugin](https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins). This means any sample can
+be downloaded and used directly within a build.
+
+```groovy
+// build.gradle
+apply from: 'build-data-capturing-sample.gradle'
+```
+
+```kotlin
+// build.gradle.kts
+apply(from = "build-data-capturing-sample.gradle.kts")
+```
+
 ## Overview
 
 This directory contains samples demonstrating various ways to extend and customize a Build Scan with extra data using 
@@ -78,19 +94,3 @@ _Demonstrates: Custom values, Custom tags_
 This sample adds a custom value for macOS builds that captures the average amount of thermal throttling that was 
 applied during the build, a technique where the CPU is throttled in an effort to reduce heat. It then applies a tag to 
 the Build Scan that maps the percentage to a level of thermal throttling.
-
-## Usage
-
-Each sample has been written as
-a [script plugin](https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins). This means any sample can
-be downloaded and used directly within a build.
-
-```groovy
-// build.gradle
-apply from: 'build-data-capturing-sample.gradle'
-```
-
-```kotlin
-// build.gradle.kts
-apply(from = "build-data-capturing-sample.gradle.kts")
-```

--- a/build-data-capturing-gradle-samples/README.md
+++ b/build-data-capturing-gradle-samples/README.md
@@ -29,7 +29,7 @@ on [Extending build scans](https://docs.gradle.com/enterprise/gradle-plugin/#ext
 _Demonstrates: Custom values_
 
 This sample demonstrates how to capture the Gradle Enterprise Gradle plugin version as a custom value. This can be used
-to identify and filter for projects using a certain version of the plugin within the Build Scan dashboard.
+to identify and filter for projects using a certain version of the plugin on the Gradle Enterprise dashboards.
 
 ### Capture Git Diffs
 

--- a/build-data-capturing-gradle-samples/README.md
+++ b/build-data-capturing-gradle-samples/README.md
@@ -17,7 +17,7 @@ on [Extending build scans](https://docs.gradle.com/enterprise/gradle-plugin/#ext
 _Demonstrates: Custom values_
 
 This sample demonstrates how to capture the Gradle Enterprise Gradle plugin version as a custom value. This can be used
-to identify projects using a certain version of the plugin within the Build Scan dashboard.
+to identify and filter for projects using a certain version of the plugin within the Build Scan dashboard.
 
 ### Capture Git Diffs
 
@@ -77,14 +77,13 @@ _Demonstrates: Custom values, Custom tags_
 
 This sample adds a custom value for macOS builds that captures the average amount of thermal throttling that was 
 applied during the build, a technique where the CPU is throttled in an effort to reduce heat. It then applies a tag to 
-the Build Scan that maps the percentage to a "level of thermal throttling".
+the Build Scan that maps the percentage to a level of thermal throttling.
 
 ## Usage
 
-The purpose of these samples is to demonstrate different ways to capture custom data and use it to customize a Build
-Scan. However, each sample has been written as
-a [script plugin](https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins), allowing any sample to be 
-used directly within a build.
+Each sample has been written as
+a [script plugin](https://docs.gradle.org/current/userguide/plugins.html#sec:script_plugins). This means any sample can
+be downloaded and used directly within a build.
 
 ```groovy
 // build.gradle

--- a/build-data-capturing-gradle-samples/capture-ge-plugin-version/gradle-ge-plugin-version.gradle
+++ b/build-data-capturing-gradle-samples/capture-ge-plugin-version/gradle-ge-plugin-version.gradle
@@ -1,7 +1,5 @@
 /**
  * This Groovy script captures the Gradle Enterprise Gradle plugin version as a custom value.
- *
- * <code> apply from: file('gradle-ge-plugin-version.gradle') </code>
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle
+++ b/build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit
  * In order for the gist to be created successfully, you must specify the Gradle property `gistToken` where
  * the value is a Github access token that has gist permission on the given Github repo.
  *
- * See https://docs.github.com/en/free-pro-team@latest/rest/reference/gists#create-a-gist for reference.
+ * See https://docs.github.com/en/rest/gists/gists#create-a-gist for reference.
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle
+++ b/build-data-capturing-gradle-samples/capture-git-diffs/gradle-git-diffs.gradle
@@ -7,8 +7,6 @@ import java.util.concurrent.TimeUnit
 /**
  * This Gradle script captures the <i>Git diff</i> in a GitHub gist,
  * and references the gist via a custom link.
- * This should be applied to the root project:
- * <code> apply from: file('gradle-git-diffs.gradle') </code>
  *
  * In order for the gist to be created successfully, you must specify the Gradle property `gistToken` where
  * the value is a Github access token that has gist permission on the given Github repo.

--- a/build-data-capturing-gradle-samples/capture-os-processes/gradle-os-processes.gradle
+++ b/build-data-capturing-gradle-samples/capture-os-processes/gradle-os-processes.gradle
@@ -4,8 +4,6 @@ import java.util.concurrent.TimeUnit
 /**
  * This Gradle script captures the OS processes as reported by the OS 'ps' command,
  * and adds these as a custom value.
- * This should be applied to the root project:
- * <code> apply from: file('gradle-os-processes.gradle') </code>
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-processor-arch/gradle-processor-arch.gradle
+++ b/build-data-capturing-gradle-samples/capture-processor-arch/gradle-processor-arch.gradle
@@ -4,8 +4,6 @@ import java.util.concurrent.TimeUnit
 /**
  * This Gradle script captures the processor architecture
  * and adds these as a custom value.
- * This should be applied to the root project:
- * <code> apply from: file('gradle-processor-arch.gradle') </code>
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
+++ b/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
@@ -1,8 +1,6 @@
 /**
  * This Gradle script captures issues found by reporting tasks,
  * and adds these as custom values.
- * This should be applied to the root project:
- * <code> apply from: file('gradle-quality-check-issues.gradle') </code>
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-slow-workunit-executions/gradle-slow-task-executions.gradle
+++ b/build-data-capturing-gradle-samples/capture-slow-workunit-executions/gradle-slow-task-executions.gradle
@@ -1,8 +1,6 @@
 /**
  * This Gradle script captures all tasks of a given type taking longer to execute than a certain threshold,
  * and adds these as custom values.
- * This should be applied to the root project:
- * <code> apply from: file('gradle-slow-task-executions.gradle') </code>
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-execution-system-properties/gradle-test-execution-system-properties.gradle
@@ -4,8 +4,6 @@ import java.security.MessageDigest
 /**
  * This Gradle script captures the system properties available to each Test task, hashes the properties' values,
  * and adds these as custom values.
- * This should be applied to the root project since it configures all projects:
- * <code> apply from: file('gradle-test-execution-system-properties.gradle') </code>
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -8,8 +8,6 @@ import groovy.transform.Field
 /**
  * This Gradle script captures Predictive Test Selection and Test Distribution compatibility for each Test task, 
  * adding a flag as custom value.
- * This should be applied to the root project since it configures all projects:
- * <code> apply from: file('gradle-test-pts-support.gradle') </code>
  */
 
 def buildScanApi = project.extensions.findByName('buildScan')

--- a/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
+++ b/build-data-capturing-gradle-samples/capture-thermal-throttling/gradle-thermal-throttling.gradle
@@ -19,9 +19,6 @@ import org.gradle.tooling.events.FinishEvent
  *
  * WARNINGS:
  * - This is supported on MacOS only.
- *
- * This should be applied to the root project:
- * <code> apply from: file('gradle-thermal-throttling.gradle') </code>
  */
 
 if (OperatingSystem.current().macOsX) {

--- a/build-data-capturing-maven-samples/README.md
+++ b/build-data-capturing-maven-samples/README.md
@@ -21,7 +21,7 @@ on [Extending build scans](https://docs.gradle.com/enterprise/maven-extension/#e
 _Demonstrates: Custom values_
 
 This sample demonstrates how to capture the Gradle Enterprise Maven extension version as a custom value. This can be 
-used to identify and filter for projects using a certain version of the extension within the Build Scan dashboard.
+used to identify and filter for projects using a certain version of the extension on the Gradle Enterprise dashboards.
 
 ### Capture OS Processes
 

--- a/build-data-capturing-maven-samples/README.md
+++ b/build-data-capturing-maven-samples/README.md
@@ -58,4 +58,8 @@ This sample captures the top-level project name and artifact ID and adds these a
 
 ## Usage
 
-[//]: # (todo not sure how these are intended to be applied)
+Each sample has been written to be fully compatible with
+the [Common Custom User Data Maven extension](https://github.com/gradle/common-custom-user-data-maven-extension). This
+means any sample can be downloaded and included in a Maven build that uses the extension. See
+the [Capturing additional tags, links, and values in your build scans](https://github.com/gradle/common-custom-user-data-maven-extension#capturing-additional-tags-links-and-values-in-your-build-scans)
+section of the extension documentation for more information.

--- a/build-data-capturing-maven-samples/README.md
+++ b/build-data-capturing-maven-samples/README.md
@@ -13,7 +13,7 @@ on [Extending build scans](https://docs.gradle.com/enterprise/maven-extension/#e
 _Demonstrates: Custom values_
 
 This sample demonstrates how to capture the Gradle Enterprise Maven extension version as a custom value. This can be 
-used to identify projects using a certain version of the extension within the Build Scan dashboard.
+used to identify and filter for projects using a certain version of the extension within the Build Scan dashboard.
 
 ### Capture OS Processes
 

--- a/build-data-capturing-maven-samples/README.md
+++ b/build-data-capturing-maven-samples/README.md
@@ -1,5 +1,13 @@
 # Build Data Capturing Maven Samples
 
+## Usage
+
+Each sample has been written to be fully compatible with
+the [Common Custom User Data Maven extension](https://github.com/gradle/common-custom-user-data-maven-extension). This
+means any sample can be downloaded and included in a Maven build that uses the extension. See
+the [Capturing additional tags, links, and values in your build scans](https://github.com/gradle/common-custom-user-data-maven-extension#capturing-additional-tags-links-and-values-in-your-build-scans)
+section of the extension documentation for more information.
+
 ## Overview
 
 This directory contains samples demonstrating various ways to extend and customize a Build Scan with extra data using 
@@ -55,11 +63,3 @@ the Build Scan that maps the percentage to a "level of thermal throttling".
 _Demonstrates: Custom values_
 
 This sample captures the top-level project name and artifact ID and adds these as custom values on the Build Scan.
-
-## Usage
-
-Each sample has been written to be fully compatible with
-the [Common Custom User Data Maven extension](https://github.com/gradle/common-custom-user-data-maven-extension). This
-means any sample can be downloaded and included in a Maven build that uses the extension. See
-the [Capturing additional tags, links, and values in your build scans](https://github.com/gradle/common-custom-user-data-maven-extension#capturing-additional-tags-links-and-values-in-your-build-scans)
-section of the extension documentation for more information.

--- a/build-data-capturing-maven-samples/README.md
+++ b/build-data-capturing-maven-samples/README.md
@@ -1,0 +1,61 @@
+# Build Data Capturing Maven Samples
+
+## Overview
+
+This directory contains samples demonstrating various ways to extend and customize a Build Scan with extra data using 
+tags, links, and custom values.
+
+To learn more, see the Gradle Enterprise documentation
+on [Extending build scans](https://docs.gradle.com/enterprise/maven-extension/#extending_build_scans).
+
+### Capture GE Extension Version
+
+_Demonstrates: Custom values_
+
+This sample demonstrates how to capture the Gradle Enterprise Maven extension version as a custom value. This can be 
+used to identify projects using a certain version of the extension within the Build Scan dashboard.
+
+### Capture OS Processes
+
+_Demonstrates: Custom values_
+
+This sample captures the output of the `ps` command and adds it to the Build Scan as a custom value named
+`OS processes`.
+
+### Capture Processor Arch
+
+_Demonstrates: Custom values, Custom tags_
+
+This sample adds the operating system name and processor architecture as custom values and adds a tag to the Build Scan
+if the build was executed on an M1 processor.
+
+### Capture Profiles
+
+_Demonstrates: Custom tags_
+
+This sample captures each active Maven profile and adds it as a tag on the Build Scan. 
+
+### Capture Quality Check Issues
+
+_Demonstrates: Custom values_
+
+This sample parses the XML reports of several common quality check plugins and includes the findings as custom values on
+the corresponding Build Scan.
+
+### Capture Thermal Throttling
+
+_Demonstrates: Custom values, Custom tags_
+
+This sample adds a custom value for macOS builds that captures the average amount of thermal throttling that was 
+applied during the build, a technique where the CPU is throttled in an effort to reduce heat. It then applies a tag to 
+the Build Scan that maps the percentage to a "level of thermal throttling".
+
+### Capture Top Level Project
+
+_Demonstrates: Custom values_
+
+This sample captures the top-level project name and artifact ID and adds these as custom values on the Build Scan.
+
+## Usage
+
+[//]: # (todo not sure how these are intended to be applied)


### PR DESCRIPTION
This PR adds a README at the root of `build-data-capturing-gradle-samples` and `build-data-capturing-maven-samples` that provides an overview of each sample as well as how to include them in a build. 