### PR TITLE
Remove unecessary task.configure block in quality check sample

### DIFF
--- a/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
+++ b/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
@@ -15,7 +15,7 @@ gradle.taskGraph.beforeTask { task ->
         return
     }
 
-    task.configure { t -> t.reports.xml.required = true }
+    task.reports.xml.required = true
 }
 
 gradle.taskGraph.afterTask { task, TaskState state ->


### PR DESCRIPTION
Works fine without and does not cause eager task configuration