### PR TITLE
Add Maven CI steps to verify that no cacheable goals execute

### DIFF
--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -34,12 +34,9 @@ jobs:
             -a "-Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B" \
             -s "https://ge.solutions-team.gradle.com" \
             -f 2>&1 | tee -a /tmp/build.log
+          echo "hasUnknownParams=$(grep "Build caching was not enabled for this goal execution because the following parameters were not handled" /tmp/build.log | wc -l)" >> $GITHUB_OUTPUT
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
       - name: Verify no unmapped mojo parameters
-        if: success() || failure()
-        run: |
-          hasUnknownParams="$(grep 'Build caching was not enabled for this goal execution because the following parameters were not handled' /tmp/build.log | wc -l)"
-          if [[ "$hasUnknownParams" != "0" ]]; then
-            exit 1
-          fi
+        if: (success() || failure()) && steps.build.outputs.hasUnknownParams != '0'
+        run: exit 1

--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -7,8 +7,9 @@ jobs:
     name: Verification
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@actions-stable
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -20,27 +21,25 @@ jobs:
           node-version: '14'
       - name: Set up Yarn
         run: npm install -g yarn
-      - name: First build
-        id: first-build
-        working-directory: ./build-caching-maven-samples
+      - name: Run build validation scripts
+        id: build
+        working-directory: gradle-enterprise-maven-build-validation
         run: |
           set -o pipefail
-          ./mvnw clean verify -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com -Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B 2>&1 | tee -a /tmp/first-build.log
-          echo "hasUnknownParams=$(grep "Build caching was not enabled for this goal execution because the following parameters were not handled" /tmp/first-build.log | wc -l)" >> $GITHUB_OUTPUT
-        env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
-      - name: Second build
-        id: second-build
-        working-directory: ./build-caching-maven-samples
-        run: |
-          set -o pipefail
-          ./mvnw clean verify -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com -Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B 2>&1 | tee -a /tmp/second-build.log
-          echo "executedCacheableGoals=$(grep "Local cache miss" /tmp/second-build.log | wc -l)" >> $GITHUB_OUTPUT
+          ./02-validate-local-build-caching-different-locations.sh \
+            -r "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" \
+            -c "${{ github.sha }}" \
+            -p "build-caching-maven-samples" \
+            -g "verify" \
+            -a "-Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B" \
+            -s "https://ge.solutions-team.gradle.com" \
+            -f 2>&1 | tee -a /tmp/build.log
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
       - name: Verify no unmapped mojo parameters
-        run: if [[ "${{ steps.first-build.outputs.hasUnknownParams }}" != "0" ]]; then exit 1; fi
         if: success() || failure()
-      - name: Verify no executed cacheable goals
-        run: if [[ "${{ steps.second-build.outputs.executedCacheableGoals }}" != "0" ]]; then exit 1; fi
-        if: success() || failure()
+        run: |
+          hasUnknownParams="$(grep 'Build caching was not enabled for this goal execution because the following parameters were not handled' /tmp/build.log | wc -l)"
+          if [[ "$hasUnknownParams" != "0" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '14'
       - name: Set up Yarn
         run: npm install -g yarn
-      - name: Run build validation scripts
+      - name: Verify cacheable goals are retrieved from the build cache
         id: build
         working-directory: gradle-enterprise-maven-build-validation
         run: |

--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -28,7 +28,7 @@ jobs:
           set -o pipefail
           ./02-validate-local-build-caching-different-locations.sh \
             -r "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" \
-            -c "${{ github.sha }}" \
+            -c "$GITHUB_SHA" \
             -p "build-caching-maven-samples" \
             -g "verify" \
             -a "-Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B" \

--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -20,15 +20,27 @@ jobs:
           node-version: '14'
       - name: Set up Yarn
         run: npm install -g yarn
-      - name: Build with Maven
-        id: mvn-build
+      - name: First build
+        id: first-build
         working-directory: ./build-caching-maven-samples
         run: |
           set -o pipefail
-          ./mvnw clean verify -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com -Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B 2>&1 | tee -a /tmp/gradle-build.log
-          echo "hasUnknownParams=$(grep "Build caching was not enabled for this goal execution because the following parameters were not handled" /tmp/gradle-build.log | wc -l)" >> $GITHUB_OUTPUT
+          ./mvnw clean verify -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com -Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B 2>&1 | tee -a /tmp/first-build.log
+          echo "hasUnknownParams=$(grep "Build caching was not enabled for this goal execution because the following parameters were not handled" /tmp/first-build.log | wc -l)" >> $GITHUB_OUTPUT
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
-      - name: Fail if unmapped mojo parameters
-        run: exit 1
-        if:  steps.mvn-build.outputs.hasUnknownParams != '0'
+      - name: Second build
+        id: second-build
+        working-directory: ./build-caching-maven-samples
+        run: |
+          set -o pipefail
+          ./mvnw clean verify -Dgradle.enterprise.url=https://ge.solutions-team.gradle.com -Dorg.slf4j.simpleLogger.log.gradle.goal.cache=debug -B 2>&1 | tee -a /tmp/second-build.log
+          echo "executedCacheableGoals=$(grep "Local cache miss" /tmp/second-build.log | wc -l)" >> $GITHUB_OUTPUT
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+      - name: Verify no unmapped mojo parameters
+        run: if [[ "${{ steps.first-build.outputs.hasUnknownParams }}" != "0" ]]; then exit 1; fi
+        if: success() || failure()
+      - name: Verify no executed cacheable goals
+        run: if [[ "${{ steps.second-build.outputs.executedCacheableGoals }}" != "0" ]]; then exit 1; fi
+        if: success() || failure()


### PR DESCRIPTION
This PR uses the [Gradle Enterprise Maven build validation scripts](https://github.com/gradle/gradle-enterprise-build-validation-scripts) to verify the cacheability of the Maven build caching samples.

I tested this by verifying all four possible verification outcomes:

- [An unmapped parameter exists](https://github.com/gradle/gradle-enterprise-build-config-samples/actions/runs/3660849119/jobs/6188448567)
- [A cacheable goal was executed](https://github.com/gradle/gradle-enterprise-build-config-samples/actions/runs/3660801947/jobs/6188351210)
- [Found neither unmapped parameters nor executed cacheable goals](https://github.com/gradle/gradle-enterprise-build-config-samples/actions/runs/3660832432/jobs/6188413057)
- [Found both unmapped parameters and executed cacheable goals](https://github.com/gradle/gradle-enterprise-build-config-samples/actions/runs/3660780515/jobs/6188309387)