### PR TITLE
Update AspectJ build caching configuration

### DIFF
--- a/build-caching-maven-samples/aspectj-project/pom.xml
+++ b/build-caching-maven-samples/aspectj-project/pom.xml
@@ -175,7 +175,6 @@
                                             <ignore>XterminateAfterCompilation</ignore>
                                             <ignore>argumentFileName</ignore>
                                             <ignore>warn</ignore>
-                                            <ignore>additionalAspectPaths</ignore>
                                         </ignoredProperties>
                                     </inputs>
                                     <iteratedProperties>
@@ -276,6 +275,7 @@
                                                 <ignoredProperties>
                                                     <ignore>testAspectDirectory</ignore>
                                                     <ignore>sources</ignore>
+                                                    <ignore>additionalAspectPaths</ignore>
                                                 </ignoredProperties>
                                             </inputs>
                                             <outputs>
@@ -294,6 +294,14 @@
                                                         <name>testAspectDirectory</name>
                                                         <includesProperty>includes</includesProperty>
                                                         <excludesProperty>excludes</excludesProperty>
+                                                        <normalization>
+                                                            <strategy>RELATIVE_PATH</strategy>
+                                                            <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                                                            <ignoreLineEndings>true</ignoreLineEndings>
+                                                        </normalization>
+                                                    </fileSet>
+                                                    <fileSet>
+                                                        <name>additionalAspectPaths</name>
                                                         <normalization>
                                                             <strategy>RELATIVE_PATH</strategy>
                                                             <ignoreEmptyDirectories>true</ignoreEmptyDirectories>


### PR DESCRIPTION
The additionalAspectPaths property needs to be tracked as file set and only on the test compile goal, as the compile goal returns null for that property.