### PR TITLE
Remove `rollout-maven-extension` from dependabot check.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,10 +11,6 @@ updates:
     schedule:
       interval: "daily"
   - package-ecosystem: "maven"
-    directory: "rollout-maven-extension"
-    schedule:
-      interval: "daily"
-  - package-ecosystem: "maven"
     directory: "common-gradle-enterprise-maven-configuration"
     schedule:
       interval: "daily"


### PR DESCRIPTION
This check currently fails to execute because `rollout-maven-extension` contains no `pom.xml`. The updates to `extensions.xml` are done manually.