### PR TITLE
Fix duplicate CI jobs from running on PRs

### DIFF
--- a/.github/workflows/gradle-data-capturing-samples-verification.yml
+++ b/.github/workflows/gradle-data-capturing-samples-verification.yml
@@ -1,6 +1,11 @@
 name: Verify Gradle Data Capturing Samples
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   verification:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,6 +1,11 @@
 name: Validate Gradle Wrapper
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   validation:

--- a/.github/workflows/maven-build-caching-samples-verification.yml
+++ b/.github/workflows/maven-build-caching-samples-verification.yml
@@ -1,6 +1,11 @@
 name: Verify Maven Build Caching Samples
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   verification:

--- a/.github/workflows/maven-data-capturing-samples-verification.yml
+++ b/.github/workflows/maven-data-capturing-samples-verification.yml
@@ -1,6 +1,11 @@
 name: Verify Maven Data Capturing Samples
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   verification:

--- a/.github/workflows/shell-script-validation.yml
+++ b/.github/workflows/shell-script-validation.yml
@@ -1,6 +1,11 @@
 name: Validate Shell Scripts
 
-on: [ push, pull_request, workflow_dispatch ]
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
   validation:


### PR DESCRIPTION
You may notice on other PRs that we are running each job twice. For example:

![image](https://user-images.githubusercontent.com/5797900/222040124-02cf9b97-832a-4e35-9568-48ae8e81938a.png)

Notice the duplicate job names. This is because they are matching both the `pull_request` and `push` condition of the workflow.

This PR updates the conditions for when CI jobs are triggered in such a way that there is no overlap. Jobs will run when either:

- A pull request against `main` is opened or reopened or when the head branch of the pull request is updated, or
- A push to the `main` branch has been made

⚠️ This does create a gap between current behavior in that with these changes CI will not run for branches which do not have an open pull request or are not `main`. Additionally, CI will not run if an open pull request is not pointing against `main`.

I am open to ideas on other solutions. This is what is already being done in [android-cache-fix-gradle-plugin](https://github.com/gradle/android-cache-fix-gradle-plugin/blob/631b36ea45d9a9f40280b0719a1e9d5e68f00d91/.github/workflows/build-verification.yml#L3-L8) and is also mentioned [as a recommendation here](https://github.com/orgs/community/discussions/26276).

Once we come to a conclusion, I can update our other repositories where this is happening too. This one just suffers the most from this issue.