### PR TITLE
Best effort fix for CodeNarc caputring issue

### DIFF
--- a/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
+++ b/build-data-capturing-gradle-samples/capture-quality-check-issues/gradle-quality-check-issues.gradle
@@ -39,9 +39,16 @@ gradle.taskGraph.afterTask { task, TaskState state ->
     } else if (ReportingTask.CODENARC.isTask(task)) {
         valueName = 'Verification CodeNarc'
         errors = report.Package.collect {
-            def sourceDirectory = appendIfMissing(it.parent().Project.SourceDirectory.text() as String, '/')
+            def sourceDirectories = it.parent().Project.SourceDirectory.collect {
+                appendIfMissing(it.text() as String, '/')
+            }.unique()
             it.File.collect {
-                String filePath = task.project.rootProject.relativePath(sourceDirectory + (it.@name.text() as String))
+                File fileWithViolation = sourceDirectories.collect { sourceDirectory ->
+                    task.project.file(sourceDirectory + (it.@name.text() as String))
+                }.find {
+                    it.exists()
+                }
+                String filePath = task.project.rootProject.relativePath(fileWithViolation)
                 it.Violation.collect { "${filePath}:${it.@lineNumber} \u2192 ${it.Message.text()}" }
             }.flatten()
         }.flatten() as List<String>


### PR DESCRIPTION
The previous version of the code assumed that the CodeNarc XML report
would always just contain a single `SourceDirectory` element. It turns
out that that is not true with the CodeNarc version we're using. There's
a `SourceDirectory` element for each package of the tested module. The
code then prepended all the `SourceDirectory` elements in front of each
file, which resulted in broken path being rendered into the custom
value.

With this commit the code now tries to find the right `SourceDirectory`
element by iterating over all of them and then checking whether the
violating file exists in that directory. This results in correct paths
being rendered. However it can result in the wrong file being reported
in case files with identical file names exist in different directories.
