### PR TITLE
Bump Gradle Enterprise Maven Extension to 1.16.5

### DIFF
--- a/custom-maven-distribution/create-custom-maven-distribution.sh
+++ b/custom-maven-distribution/create-custom-maven-distribution.sh
@@ -32,7 +32,7 @@ maven_conf=${maven_dir}/conf
 custom_maven_version=1.0.0
 custom_maven_zip=${maven_dir}-sample-${custom_maven_version}-bin.zip
 
-ge_ext_version=1.16.4
+ge_ext_version=1.16.5
 ge_ext_jar=gradle-enterprise-maven-extension-${ge_ext_version}.jar
 
 ge_sample_ext_version=1.11.1

--- a/rollout-maven-extension/.mvn/extensions.xml
+++ b/rollout-maven-extension/.mvn/extensions.xml
@@ -7,7 +7,7 @@
     <extension>
         <groupId>com.gradle</groupId>
         <artifactId>gradle-enterprise-maven-extension</artifactId>
-        <version>1.16.4</version>
+        <version>1.16.5</version>
     </extension>
     <extension>
         <groupId>com.gradle</groupId>


### PR DESCRIPTION
This PR bumps the Gradle Enterprise Maven Extension version to 1.16.5 for the `custom-maven-distribution` and `rollout-maven-extension`.