### PR TITLE
define upToDateChecking as nestedProperty in spotless project

### DIFF
--- a/build-caching-maven-samples/spotless-project/pom.xml
+++ b/build-caching-maven-samples/spotless-project/pom.xml
@@ -118,6 +118,16 @@
                                         </property>
                                         <property>
                                             <name>upToDateChecking</name>
+                                            <inputs>
+                                                <properties>
+                                                    <property>
+                                                        <name>enabled</name>
+                                                    </property>
+                                                    <property>
+                                                        <name>indexFile</name>
+                                                    </property>
+                                                </properties>
+                                            </inputs>
                                         </property>
                                         <!-- Entities used by Spotless with parameters defined in FormatterFactory -->
                                         <property>

--- a/build-caching-maven-samples/spotless-project/pom.xml
+++ b/build-caching-maven-samples/spotless-project/pom.xml
@@ -88,9 +88,6 @@
                                             <property>
                                                 <name>ratchetFrom</name>
                                             </property>
-                                            <property>
-                                                <name>upToDateChecking</name>
-                                            </property>
                                         </properties>
                                         <ignoredProperties>
                                             <ignore>repositorySystemSession</ignore>
@@ -118,6 +115,9 @@
                                                     </property>
                                                 </properties>
                                             </inputs>
+                                        </property>
+                                        <property>
+                                            <name>upToDateChecking</name>
                                         </property>
                                         <!-- Entities used by Spotless with parameters defined in FormatterFactory -->
                                         <property>


### PR DESCRIPTION
`spotless-maven-plugin` 2.35 enables incremental up-to-date checking by [default](https://github.com/diffplug/spotless/commit/24abb541e5df9c69acc9333ffec1137099494eef).

Testing the Spotless sample we noticed a cache miss for the goal:
https://ge.solutions-team.gradle.com/s/cmpz3xlajgdfo/timeline?cacheability=any-non-cacheable&details=odnx7yg3zoncs
`'upToDateChecking' contains unsupported type: UpToDateChecking.`


This PR updates the Spotless configuration defining the property `upToDateChecking` as nestedProperty.
https://ge.solutions-team.gradle.com/s/cmpz3xlajgdfo/timeline?cacheability=any-non-cacheable&details=odnx7yg3zoncs
