### PR TITLE
Apply Line Ending and Empty Directory Normalization to `kotlin:compile`'s `sourceDirs` Input

### DIFF
--- a/build-caching-maven-samples/kotlin-project/pom.xml
+++ b/build-caching-maven-samples/kotlin-project/pom.xml
@@ -107,6 +107,7 @@
                                             <fileSet>
                                                 <name>sourceDirs</name>
                                                 <normalization>
+                                                    <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
                                                     <ignoreLineEndings>true</ignoreLineEndings>
                                                 </normalization>
                                             </fileSet>

--- a/build-caching-maven-samples/kotlin-project/pom.xml
+++ b/build-caching-maven-samples/kotlin-project/pom.xml
@@ -106,6 +106,9 @@
                                         <fileSets>
                                             <fileSet>
                                                 <name>sourceDirs</name>
+                                                <normalization>
+                                                    <ignoreLineEndings>true</ignoreLineEndings>
+                                                </normalization>
                                             </fileSet>
                                             <fileSet>
                                                 <name>classpath</name>


### PR DESCRIPTION
Resolves #568

In the `kotlin-project` build config sample project, apply line ending and empty directory normalization to the `sourceDirs` input.

### Tests

#### Line ending normalization 
* Run a build, change `App.kt` line endings from `LF` to `CLRF`. Then run a second build. With line ending normalization applied, the `kotlin:compile` goal should come from cache.
  * [Goal input comparison WITHOUT line ending normalization applied](https://ge.solutions-team.gradle.com/c/zqt64xwt76cco/q367aa4kcwqki/goal-inputs?expanded=WyJtNXBrYjdkYm1zYnN3LXNvdXJjZWRpcnMiXQ) - `kotlin:compile` has input differences and [does not come from cache](https://ge.solutions-team.gradle.com/s/zqt64xwt76cco/timeline?details=m5pkb7dbmsbsw).
  * [Goal input comparison WITH line ending normalization applied](https://ge.solutions-team.gradle.com/c/bgecxxuyxk62g/z2g46dhzxj4hy/goal-inputs) - `kotlin:compile` has no input differences and [comes from cache](https://ge.solutions-team.gradle.com/s/bgecxxuyxk62g/timeline?details=m5pkb7dbmsbsw).

#### Empty Directory Normalization
* Run a build, create `src/main/kotlin/test` directory, then run a second build. With empty directory normalization applied, the `kotlin:compile` goal should come from cache.
  * [Goal input comparison WITHOUT empty directory normalization applied](https://ge.solutions-team.gradle.com/c/li6eied4mwhuc/droqzupay7a4s/goal-inputs?expanded=WyJtNXBrYjdkYm1zYnN3LXNvdXJjZWRpcnMiLCJtNXBrYjdkYm1zYnN3LXNvdXJjZURpcnMtMC0wIl0#change-m5pkb7dbmsbsw-sourceDirs-0-0-0) - `kotlin:compile` has input differences and [does not come from cache](https://ge.solutions-team.gradle.com/s/li6eied4mwhuc/timeline?details=m5pkb7dbmsbsw).
  * [Goal input comparison WITH line ending normalization applied](https://ge.solutions-team.gradle.com/c/fontpd6etb3no/rhysfv65ddgom/goal-inputs) - `kotlin:compile` has no input differences and [comes from cache](https://ge.solutions-team.gradle.com/s/fontpd6etb3no/timeline?details=m5pkb7dbmsbsw)