### PR TITLE
Apply necessary normalization to build-caching-maven-samples projects

### DIFF
--- a/build-caching-maven-samples/antlr3-project/pom.xml
+++ b/build-caching-maven-samples/antlr3-project/pom.xml
@@ -70,9 +70,17 @@
                     <fileSets>
                       <fileSet>
                         <name>sourceDirectory</name>
+                        <normalization>
+                          <ignoreLineEndings>true</ignoreLineEndings>
+                          <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                        </normalization>
                       </fileSet>
                       <fileSet>
                         <name>libDirectory</name>
+                        <normalization>
+                          <ignoreLineEndings>true</ignoreLineEndings>
+                          <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                        </normalization>
                       </fileSet>
                     </fileSets>
                     <properties>

--- a/build-caching-maven-samples/asciidoctor-project/pom.xml
+++ b/build-caching-maven-samples/asciidoctor-project/pom.xml
@@ -69,6 +69,10 @@
                     <fileSets>
                       <fileSet>
                         <name>sourceDirectory</name>
+                        <normalization>
+                          <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                          <ignoreLineEndings>true</ignoreLineEndings>
+                        </normalization>
                       </fileSet>
                       <fileSet>
                         <name>templateDirs</name>

--- a/build-caching-maven-samples/avro-project/pom.xml
+++ b/build-caching-maven-samples/avro-project/pom.xml
@@ -75,6 +75,10 @@
                         <name>sourceDirectory</name>
                         <includesProperty>includes</includesProperty>
                         <excludesProperty>excludes</excludesProperty>
+                        <normalization>
+                          <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                          <ignoreLineEndings>true</ignoreLineEndings>
+                        </normalization>
                       </fileSet>
                       <fileSet>
                         <name>testSourceDirectory</name>

--- a/build-caching-maven-samples/clojure-project/pom.xml
+++ b/build-caching-maven-samples/clojure-project/pom.xml
@@ -123,9 +123,17 @@
                       </fileSet>
                       <fileSet>
                         <name>testSourceDirectories</name>
+                        <normalization>
+                          <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                          <ignoreLineEndings>true</ignoreLineEndings>
+                        </normalization>
                       </fileSet>
                       <fileSet>
                         <name>sourceDirectories</name>
+                        <normalization>
+                          <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                          <ignoreLineEndings>true</ignoreLineEndings>
+                        </normalization>
                       </fileSet>
                       <fileSet>
                         <name>generatedSourceDirectory</name>

--- a/build-caching-maven-samples/exec-yarn-project/pom.xml
+++ b/build-caching-maven-samples/exec-yarn-project/pom.xml
@@ -70,6 +70,10 @@
                               <path>${project.basedir}/src</path>
                               <path>${project.basedir}/public</path>
                             </paths>
+                            <normalization>
+                              <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                              <ignoreLineEndings>true</ignoreLineEndings>
+                            </normalization>
                           </fileSet>
                           <fileSet>
                             <name>build-files</name>
@@ -77,6 +81,9 @@
                               <path>${project.basedir}/package.json</path>
                               <path>${project.basedir}/yarn.lock</path>
                             </paths>
+                            <normalization>
+                              <ignoreLineEndings>true</ignoreLineEndings>
+                            </normalization>
                           </fileSet>
                         </fileSets>
                         <!-- Many properties that _can_ be configured on the `exec-maven-plugin`. They should be tracked as inputs. -->

--- a/build-caching-maven-samples/pmd-project/pom.xml
+++ b/build-caching-maven-samples/pmd-project/pom.xml
@@ -50,11 +50,19 @@
                             <name>compileSourceRoots</name>
                             <includesProperty>includes</includesProperty>
                             <excludesProperty>excludes</excludesProperty>
+                            <normalization>
+                              <ignoreLineEndings>true</ignoreLineEndings>
+                              <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                            </normalization>
                           </fileSet>
                           <fileSet>
                             <name>testSourceRoots</name>
                             <includesProperty>includes</includesProperty>
                             <excludesProperty>excludes</excludesProperty>
+                            <normalization>
+                              <ignoreLineEndings>true</ignoreLineEndings>
+                              <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                            </normalization>
                           </fileSet>
                           <fileSet>
                             <name>excludeFromFailureFile</name>

--- a/build-caching-maven-samples/spotless-project/pom.xml
+++ b/build-caching-maven-samples/spotless-project/pom.xml
@@ -58,6 +58,10 @@
                                                     <exclude>.idea/*</exclude>
                                                     <exclude>target/*</exclude>
                                                 </excludes>
+                                                <normalization>
+                                                    <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                                                    <ignoreLineEndings>true</ignoreLineEndings>
+                                                </normalization>
                                             </fileSet>
                                         </fileSets>
                                         <properties>

--- a/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
+++ b/build-caching-maven-samples/spring-cloud-contract-project/pom.xml
@@ -78,6 +78,10 @@
                             <name>contractsDirectory</name>
                             <excludesProperty>excludedFiles</excludesProperty>
                             <includesProperty>includedFiles</includesProperty>
+                            <normalization>
+                              <ignoreEmptyDirectories>true</ignoreEmptyDirectories>
+                              <ignoreLineEndings>true</ignoreLineEndings>
+                            </normalization>
                           </fileSet>
                         </fileSets>
                         <ignoredProperties>


### PR DESCRIPTION
Applies line ending and empty directory normalization to `build-caching-maven-samples` projects' inputs where missing.

This normalization was not applied to configured inputs that had no corresponding input files present.