### PR TITLE
Enhance rollout user count script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 *.DS_Store
 gradle-enterprise-unique-users.txt
 gradle-enterprise-users.txt
+gradle-enterprise-users-by-repo.csv


### PR DESCRIPTION
This PR adds a couple features to the `rollout.sh` user count script:
* Checks out repositories to a consistent location in the working directory, to enable rerunning the script without re-cloning all repos (`.tmp/repos`)
* Adds a `-s` (since # of days) flag to parameterize the timeframe used by `git log --since`
* Outputs a CSV file named `gradle-enterprise-users-by-repo.csv` listing user count by repository