### PR TITLE
Push back combine-dependabot-prs workflow 1 hour

### DIFF
--- a/.github/workflows/combine-dependabot-prs.yml
+++ b/.github/workflows/combine-dependabot-prs.yml
@@ -2,7 +2,7 @@ name: Combine Dependabot PRs
 
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 4 * * *'
   workflow_dispatch:
 
 # The minimum permissions required to run this Action


### PR DESCRIPTION
Dependabot workflow sometimes runs quite delayed, and combine-dependabot-prs should run after that