### PR TITLE
Update AspectJ configuration

### DIFF
--- a/build-caching-maven-samples/aspectj-project/pom.xml
+++ b/build-caching-maven-samples/aspectj-project/pom.xml
@@ -182,6 +182,24 @@
                                             <ignore>warn</ignore>
                                         </ignoredProperties>
                                     </inputs>
+                                    <nestedProperties>
+                                        <property>
+                                            <name>project</name>
+                                            <iteratedProperties>
+                                                <property>
+                                                    <name>artifacts</name>
+                                                    <inputs>
+                                                        <fileSets>
+                                                            <fileSet>
+                                                                <name>file</name>
+                                                                <normalization>CLASSPATH</normalization>
+                                                            </fileSet>
+                                                        </fileSets>
+                                                    </inputs>
+                                                </property>
+                                            </iteratedProperties>
+                                        </property>
+                                    </nestedProperties>
                                     <iteratedProperties>
                                         <property>
                                             <name>weaveDependencies</name>


### PR DESCRIPTION
Given the current configuration of the aspectj sample, when an upstream project invalidates the output for the compile goal, the aspectj compile goal is retrieved from the cache.  
We need to include the artifacts to the aspectJ project:

```
<nestedProperties>
    <property>
        <name>project</name>
        <iteratedProperties>
            <property>
                <name>artifacts</name>
                <inputs>
                    <fileSets>
                        <fileSet>
                            <name>file</name>
                            <normalization>CLASSPATH</normalization>
                        </fileSet>
                    </fileSets>
                </inputs>
            </property>
        </iteratedProperties>
    </property>
</nestedProperties>
```

**Test**
In main branch include new method in the interface `interface Api`, then compile again the project. Result https://ge.solutions-team.gradle.com/s/5wjom6nh2gqac/timeline?details=7t2q77uiz7ce4

With this PR,  include new method in the interface `interface Api`, then compile again the project. Result: the aspectj impl project compilation fails because is not implementing the new method in the interface:  https://ge.solutions-team.gradle.com/s/pquxjfv4vgfmk/timeline?details=aex5uvpbdz2pi