### PR TITLE
Minor improvements to user-count script

### DIFF
--- a/git-user-count/repositories.txt
+++ b/git-user-count/repositories.txt
@@ -3,4 +3,3 @@ https://github.com/gradle/maven-build-scan-quickstart
 https://github.com/gradle/android-cache-fix-gradle-plugin
 
 https://github.com/gradle/gradle-enterprise-build-config-samples
-# empty final line required

--- a/git-user-count/repositories.txt
+++ b/git-user-count/repositories.txt
@@ -3,3 +3,4 @@ https://github.com/gradle/maven-build-scan-quickstart
 https://github.com/gradle/android-cache-fix-gradle-plugin
 
 https://github.com/gradle/gradle-enterprise-build-config-samples
+# empty final line required

--- a/git-user-count/user-count.sh
+++ b/git-user-count/user-count.sh
@@ -109,10 +109,10 @@ function process_repository() {
   git reset HEAD . >& /dev/null
 
   # append unique git usernames from commits in the last X days to a file
-  git log --format="%ae" --since="$since".day | sort -u >> "$userListFile"
+  git log --format="%ae" --since="$since".day | awk '{print tolower($0)}' | sort -u >> "$userListFile"
 
   # append the number of unique git committers in the last X days to a file
-  git log --format="%ae" --since="$since".day | sort -u | wc -l | xargs echo "$1," >> "$usersByRepoFile"
+  git log --format="%ae" --since="$since".day | awk '{print tolower($0)}' | sort -u | wc -l | xargs echo "$1," >> "$usersByRepoFile"
 
   popd >& /dev/null || return
 }


### PR DESCRIPTION
I noted that its helpful to lowercase author names before deduplication. 
Also the repositories.txt file needs an empty line at the end (otherwise the last repository isn't processed).

I also noted that if a repository doesn't have any commits in the time frame specified (e.g. last 30 days) then the clone fails and the script exits. I couldn't see any easy fix for this.