### PR TITLE
Dependabot uses correct path for conventions plugin

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,14 +36,14 @@ updates:
       interval: "daily"
       time: "02:00"
   - package-ecosystem: "gradle"
-    directory: "gradle-enterprise-conventions-gradle-plugin/plugins/gradle-5-or-newer"
+    directory: "convention-gradle-enterprise-gradle-plugin/plugins/gradle-5-or-newer"
     registries:
       - gradle-plugin-portal
     schedule:
       interval: "daily"
       time: "02:00"
   - package-ecosystem: "gradle"
-    directory: "gradle-enterprise-conventions-gradle-plugin/plugins/gradle-2-through-4"
+    directory: "convention-gradle-enterprise-gradle-plugin/plugins/gradle-2-through-4"
     registries:
       - gradle-plugin-portal
     schedule:


### PR DESCRIPTION
It looks like the directory containing the conventions plugin was renamed but it was not updated in Dependabot.