### PR TITLE
Add kotest to supported engines in gradle-test-pts-support scripts

### DIFF
--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -3,7 +3,6 @@ import org.gradle.util.internal.VersionNumber
 import java.nio.charset.StandardCharsets
 import java.util.Collections
 import java.util.Optional
-import java.util.function.Predicate
 import java.util.jar.JarFile
 import java.util.stream.Stream
 import java.util.stream.Collectors
@@ -64,7 +63,7 @@ class Capture {
             Stream<String> engines = t.classpath.files.stream()
                 .filter { f -> f.name.endsWith('.jar') }
                 .filter { f -> supportedEngines.values().stream().anyMatch { e -> f.name.contains(e) } }
-                .filter(filterIncompatibleKotestVersions(t))
+                .filter { f -> isCompatibleVersion(f, t) }
                 .map { f -> findTestEngine(f) }
                 .flatMap { o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty() }
 
@@ -91,20 +90,18 @@ class Capture {
         }
     }
 
-    Predicate<File> filterIncompatibleKotestVersions(Test t) {
-        return { jar ->
-            if (jar.name.contains("kotest-runner")) {
-                def kotestVersionString = jar.name.split("-")[jar.name.split("-").length - 1].replace(".jar", "")
-                def kotestVersion = VersionNumber.parse(kotestVersionString)
-                if (VersionNumber.UNKNOWN == kotestVersion) {
-                    logger.error("Unable to parse kotest version from file name ${jar.name}")
-                    buildScanApi.value("${t.identityPath}#unknownKotestVersion", "${jar.name}")
-                    return false
-                }
-                return VersionNumber.parse("5.6.0") <= kotestVersion
-            } else {
-                return true
+    boolean isCompatibleVersion(File f, Test t) {
+        if (f.name.contains("kotest-runner")) {
+            def kotestVersionString = f.name.split("-")[f.name.split("-").length - 1].replace(".jar", "")
+            def kotestVersion = VersionNumber.parse(kotestVersionString)
+            if (VersionNumber.UNKNOWN == kotestVersion) {
+                logger.error("Unable to parse kotest version from file name ${f.name}")
+                buildScanApi.value("${t.identityPath}#unknownKotestVersion", "${f.name}")
+                return false
             }
+            return VersionNumber.parse("5.6.0") <= kotestVersion
+        } else {
+            return true
         }
     }
 }

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -32,7 +32,8 @@ class Capture {
         'org.spockframework.runtime.SpockEngine' : 'spock',
         'net.jqwik.engine.JqwikTestEngine' : 'jqwik',
         'com.tngtech.archunit.junit.ArchUnitTestEngine' : 'archunit',
-        'co.helmethair.scalatest.ScalatestEngine' : 'scalatest'
+        'co.helmethair.scalatest.ScalatestEngine' : 'scalatest',
+        'io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine' : 'kotest-runner'
     ]
     private Logger logger
 

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -1,7 +1,9 @@
 import com.gradle.scan.plugin.BuildScanExtension
+import org.gradle.util.internal.VersionNumber
 import java.nio.charset.StandardCharsets
 import java.util.Collections
 import java.util.Optional
+import java.util.function.Predicate
 import java.util.jar.JarFile
 import java.util.stream.Stream
 import java.util.stream.Collectors
@@ -15,11 +17,11 @@ def buildScanApi = project.extensions.findByName('buildScan')
 if (!buildScanApi) {
     return
 }
-def capture = new Capture(gradle.rootProject.logger)
+def capture = new Capture(buildScanApi, gradle.rootProject.logger)
 allprojects {
     tasks.withType(Test).configureEach { t ->
         doFirst {
-            capture.capturePts(t, buildScanApi)
+            capture.capturePts(t)
         }
     }
 }
@@ -36,12 +38,14 @@ class Capture {
         'io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine' : 'kotest-runner'
     ]
     private Logger logger
+    private BuildScanExtension buildScanApi
 
-    Capture(Logger logger) {
+    Capture(BuildScanExtension buildScanApi, Logger logger) {
+        this.buildScanApi = buildScanApi
         this.logger = logger
     }
 
-    void capturePts(Test t, BuildScanExtension buildScanApi) {
+    void capturePts(Test t) {
         if (t.getTestFramework().getClass().getName() == 'org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework') {
             def engines = testEngines(t)
             buildScanApi.value("${t.identityPath}#engines", "${engines}")
@@ -60,6 +64,7 @@ class Capture {
             Stream<String> engines = t.classpath.files.stream()
                 .filter { f -> f.name.endsWith('.jar') }
                 .filter { f -> supportedEngines.values().stream().anyMatch { e -> f.name.contains(e) } }
+                .filter(filterIncompatibleKotestVersions(t))
                 .map { f -> findTestEngine(f) }
                 .flatMap { o -> o.isPresent() ? Stream.of(o.get()) : Stream.empty() }
 
@@ -83,6 +88,23 @@ class Capture {
         try (def jarFile = new JarFile(jar)) {
             return Optional.ofNullable(jarFile.getEntry('META-INF/services/org.junit.platform.engine.TestEngine'))
                 .map { e -> jarFile.getInputStream(e).withCloseable { it.getText(StandardCharsets.UTF_8.name()).trim() } }
+        }
+    }
+
+    Predicate<File> filterIncompatibleKotestVersions(Test t) {
+        return { jar ->
+            if (jar.name.contains("kotest-runner")) {
+                def kotestVersionString = jar.name.split("-")[jar.name.split("-").length - 1].replace(".jar", "")
+                def kotestVersion = VersionNumber.parse(kotestVersionString)
+                if (VersionNumber.UNKNOWN == kotestVersion) {
+                    logger.error("Unable to parse kotest version from file name ${jar.name}")
+                    buildScanApi.value("${t.identityPath}#unknownKotestVersion", "${jar.name}")
+                    return false
+                }
+                return VersionNumber.parse("5.6.0") <= kotestVersion
+            } else {
+                return true
+            }
         }
     }
 }

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
@@ -1,5 +1,6 @@
 import com.gradle.enterprise.gradleplugin.GradleEnterpriseExtension
 import com.gradle.scan.plugin.BuildScanExtension
+import org.gradle.util.internal.VersionNumber
 import java.nio.charset.StandardCharsets
 import java.util.Collections
 import java.util.Optional

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
@@ -35,7 +35,8 @@ class Capture(val logger: Logger) {
         "org.spockframework.runtime.SpockEngine" to "spock",
         "net.jqwik.engine.JqwikTestEngine" to "jqwik",
         "com.tngtech.archunit.junit.ArchUnitTestEngine" to "archunit",
-        "co.helmethair.scalatest.ScalatestEngine" to "scalatest"
+        "co.helmethair.scalatest.ScalatestEngine" to "scalatest",
+        "io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine" to "kotest-runner"
     )
 
     fun capturePts(t: Test, api: BuildScanExtension) {


### PR DESCRIPTION
Applying [kotlin PTS compatibility script plugin](https://ge.solutions-team.gradle.com/s/zq5ufp34tk7xe/performance/configuration?details=code-unit-gradle-test-pts-support.gradle.kts!:&openScriptsAndPlugins=WyJjb2RlLXVuaXQtZ3JhZGxlLXRlc3QtcHRzLXN1cHBvcnQuZ3JhZGxlLmt0cyJd) to project using kotest - ([custom values showing kotest engine 5.8.0 (latest version) is compatible](https://ge.solutions-team.gradle.com/s/zq5ufp34tk7xe/custom-values))

Applying [kotlin PTS compatibility script plugin](https://ge.solutions-team.gradle.com/s/m7ufnwa2ax7h6/performance/configuration?details=code-unit-gradle-test-pts-support.gradle.kts!:&openScriptsAndPlugins=WyJjb2RlLXVuaXQtZ3JhZGxlLXRlc3QtcHRzLXN1cHBvcnQuZ3JhZGxlLmt0cyJd) to project using kotest - ([custom values showing kotest engine 5.6.0 (min compatible version) is compatible](https://ge.solutions-team.gradle.com/s/m7ufnwa2ax7h6/custom-values))

Applying [kotlin PTS compatibility script plugin](https://ge.solutions-team.gradle.com/s/n4v5y7d6g7fle/performance/configuration?details=code-unit-gradle-test-pts-support.gradle.kts!:&openScriptsAndPlugins=WyJjb2RlLXVuaXQtZ3JhZGxlLXRlc3QtcHRzLXN1cHBvcnQuZ3JhZGxlLmt0cyJd) to project using kotest - ([custom values showing kotest engine 5.4.0 is NOT compatible](https://ge.solutions-team.gradle.com/s/n4v5y7d6g7fle/custom-values))