### PR TITLE
Added detecting cucumber support to pts scripts

### DIFF
--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -60,22 +60,20 @@ class Capture {
     }
 
     boolean ptsSupported(Test t, Set<String> engines) {
-        if (cucumberUsed(t) && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion')) {
-            // If cucumber is used without companion it's not supported.
-            return false
-        } else if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
-            return true
-        } else {
-            return false
-        }
+        return allEnginesSupported(engines) && !cucumberUsedWithoutCompanion(t)
     }
 
-    boolean cucumberUsed(Test t) {
-        return t.project.configurations.stream().filter { it.canBeResolved }.any {
+    boolean allEnginesSupported(Set<String> engines) {
+        return !engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }
+    }
+
+    boolean cucumberUsedWithoutCompanion(Test t) {
+        def cucumberUsed = t.project.configurations.stream().filter { it.canBeResolved }.any {
             it.resolvedConfiguration.resolvedArtifacts.any {
                 it.moduleVersion.id.group == 'io.cucumber'
             }
         }
+        return cucumberUsed && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion')
     }
 
     Set<String> testEngines(Test t) {

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -34,7 +34,8 @@ class Capture {
         'net.jqwik.engine.JqwikTestEngine' : 'jqwik',
         'com.tngtech.archunit.junit.ArchUnitTestEngine' : 'archunit',
         'co.helmethair.scalatest.ScalatestEngine' : 'scalatest',
-        'io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine' : 'kotest-runner'
+        'io.kotest.runner.junit.platform.KotestJunitPlatformTestEngine' : 'kotest-runner',
+        'io.cucumber.junit.platform.engine.CucumberTestEngine' : 'cucumber-junit-platform'
     ]
     private Logger logger
     private BuildScanExtension buildScanApi
@@ -48,7 +49,7 @@ class Capture {
         if (t.getTestFramework().getClass().getName() == 'org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestFramework') {
             def engines = testEngines(t)
             buildScanApi.value("${t.identityPath}#engines", "${engines}")
-            if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
+            if (ptsSupported(t, engines)) {
                 buildScanApi.value("${t.identityPath}#pts", 'SUPPORTED')
             } else {
                 buildScanApi.value("${t.identityPath}#pts", 'ENGINES_NOT_ALL_SUPPORTED')
@@ -56,6 +57,19 @@ class Capture {
         } else {
             buildScanApi.value("${t.identityPath}#pts", 'NO_JUNIT_PLATFORM')
         }
+    }
+
+    boolean ptsSupported(Test t, Set<String> engines) {
+        if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
+            // If cucumber is used without companion it's not supported, otherwise it is.
+            return !(cucumberUsed(t, engines) && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion'))
+        } else {
+            return false
+        }
+    }
+
+    boolean cucumberUsed(Test t, Set<String> engines) {
+        return t.classpath.any { f -> f.name.contains('cucumber')} || engines.any { it.contains('cucumber')}
     }
 
     Set<String> testEngines(Test t) {

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -62,14 +62,18 @@ class Capture {
     boolean ptsSupported(Test t, Set<String> engines) {
         if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
             // If cucumber is used without companion it's not supported, otherwise it is.
-            return !(cucumberUsed(t, engines) && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion'))
+            return !(cucumberUsed(t) && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion'))
         } else {
             return false
         }
     }
 
-    boolean cucumberUsed(Test t, Set<String> engines) {
-        return t.classpath.any { f -> f.name.contains('cucumber')} || engines.any { it.contains('cucumber')}
+    boolean cucumberUsed(Test t) {
+        return t.project.configurations.stream().filter { it.canBeResolved }.any {
+            it.resolvedConfiguration.resolvedArtifacts.any {
+                it.moduleVersion.id.group == 'io.cucumber'
+            }
+        }
     }
 
     Set<String> testEngines(Test t) {

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle
@@ -60,9 +60,11 @@ class Capture {
     }
 
     boolean ptsSupported(Test t, Set<String> engines) {
-        if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
-            // If cucumber is used without companion it's not supported, otherwise it is.
-            return !(cucumberUsed(t) && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion'))
+        if (cucumberUsed(t) && !t.project.plugins.hasPlugin('com.gradle.cucumber.companion')) {
+            // If cucumber is used without companion it's not supported.
+            return false
+        } else if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
+            return true
         } else {
             return false
         }

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
@@ -56,22 +56,20 @@ class Capture(val api: BuildScanExtension, val logger: Logger) {
     }
 
     private fun ptsSupported(t: Test, engines: Set<String>): Boolean {
-        return if (cucumberUsed(t) && !t.project.plugins.hasPlugin("com.gradle.cucumber.companion")) {
-                // If cucumber is used without companion it's not supported.
-            false
-        } else if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
-            true
-        } else {
-            false
-        }
+        return allEnginesSupported(engines) && !cucumberUsedWithoutCompanion(t)
     }
 
-    private fun cucumberUsed(t: Test): Boolean {
-        return t.project.configurations.filter { it.isCanBeResolved }.any {
+    private fun allEnginesSupported(engines: Set<String>): Boolean {
+        return !engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }
+    }
+
+    private fun cucumberUsedWithoutCompanion(t: Test): Boolean {
+        val cucumberUsed = t.project.configurations.filter { it.isCanBeResolved }.any {
             it.resolvedConfiguration.resolvedArtifacts.any {
                 it.moduleVersion.id.group == "io.cucumber"
             }
         }
+        return cucumberUsed && !t.project.plugins.hasPlugin("com.gradle.cucumber.companion")
     }
 
     private fun testEngines(t: Test): Set<String> {

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
@@ -58,14 +58,18 @@ class Capture(val api: BuildScanExtension, val logger: Logger) {
     private fun ptsSupported(t: Test, engines: Set<String>): Boolean {
         return if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
             // If cucumber is used without companion it's not supported, otherwise it is.
-            !(cucumberUsed(t, engines) && !t.project.plugins.hasPlugin("com.gradle.cucumber.companion"))
+            !(cucumberUsed(t) && !t.project.plugins.hasPlugin("com.gradle.cucumber.companion"))
         } else {
             false
         }
     }
 
-    private fun cucumberUsed(t: Test, engines: Set<String>): Boolean {
-        return t.classpath.any { f -> f.name.contains("cucumber")} || engines.any { it.contains("cucumber")}
+    private fun cucumberUsed(t: Test): Boolean {
+        return t.project.configurations.filter { it.isCanBeResolved }.any {
+            it.resolvedConfiguration.resolvedArtifacts.any {
+                it.moduleVersion.id.group == "io.cucumber"
+            }
+        }
     }
 
     private fun testEngines(t: Test): Set<String> {

--- a/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
+++ b/build-data-capturing-gradle-samples/capture-test-pts-support/gradle-test-pts-support.gradle.kts
@@ -56,9 +56,11 @@ class Capture(val api: BuildScanExtension, val logger: Logger) {
     }
 
     private fun ptsSupported(t: Test, engines: Set<String>): Boolean {
-        return if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
-            // If cucumber is used without companion it's not supported, otherwise it is.
-            !(cucumberUsed(t) && !t.project.plugins.hasPlugin("com.gradle.cucumber.companion"))
+        return if (cucumberUsed(t) && !t.project.plugins.hasPlugin("com.gradle.cucumber.companion")) {
+                // If cucumber is used without companion it's not supported.
+            false
+        } else if (!engines.isEmpty() && engines.stream().allMatch { e -> supportedEngines.containsKey(e) }) {
+            true
         } else {
             false
         }


### PR DESCRIPTION
Added detecting cucumber support to pts scripts.

Since cucumber can also be used without `cucumber-junit-platform-engine` we can't rely solely on detecting the engine, so I've added checking if any cucumber dependencies were added to the classpath of the test task. If cucumber is found, we check whether the cucumber companion plugin is added. If it's missing we mark it as `SUPPORTED`, otherwise we mark it as `ENGINES_NOT_ALL_SUPPORTED` if cucumber is detected.

This is a followup on the [slack thread](https://gradle.slack.com/archives/C02BA6P29JB/p1701256986770279)