### PR TITLE
Convention plugin for Gradle 2 through 4 uses correct build scan plugin version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,7 +51,6 @@ updates:
       time: "02:00"
     ignore:
       - dependency-name: "com.gradle:build-scan-plugin"
-        versions: [ "1.16" ]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/convention-gradle-enterprise-gradle-plugin/plugins/gradle-2-through-4/build.gradle
+++ b/convention-gradle-enterprise-gradle-plugin/plugins/gradle-2-through-4/build.gradle
@@ -13,7 +13,7 @@ repositories {
 
 dependencies {
     // must not be newer than 1.16 to be compatible with Gradle 2.x - 4.x
-    implementation "com.gradle:build-scan-plugin:2.4.2"
+    implementation "com.gradle:build-scan-plugin:1.16"
     implementation 'com.gradle:common-custom-user-data-gradle-plugin:1.12.1'
 }
 


### PR DESCRIPTION
This PR downgrades `com.gradle:build-scan-plugin` to `1.16` and removes the version constraint from Dependabot.