### PR TITLE
Build scan publishing is disabled when `properties` task is requested

### DIFF
--- a/convention-gradle-enterprise-gradle-plugin/README.md
+++ b/convention-gradle-enterprise-gradle-plugin/README.md
@@ -32,7 +32,7 @@ cd plugins/gradle-5-or-newer
 Once you have published the plugins, you can run the four example builds under `examples`:
 
 ```bash
-cd example-builds/via-build-script/gradle_6.0.1
+cd examples/gradle_6.0.1
 ./gradlew build
 ```
 

--- a/convention-gradle-enterprise-gradle-plugin/plugins/gradle-2-through-4/src/main/java/com/myorg/ConventionGradleEnterpriseGradlePlugin.java
+++ b/convention-gradle-enterprise-gradle-plugin/plugins/gradle-2-through-4/src/main/java/com/myorg/ConventionGradleEnterpriseGradlePlugin.java
@@ -3,6 +3,7 @@ package com.myorg;
 import com.gradle.CommonCustomUserDataGradlePlugin;
 import com.gradle.scan.plugin.BuildScanExtension;
 import com.gradle.scan.plugin.BuildScanPlugin;
+import org.gradle.StartParameter;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.util.GradleVersion;
@@ -18,6 +19,10 @@ public class ConventionGradleEnterpriseGradlePlugin implements Plugin<Project> {
 
     @Override
     public void apply(Project project) {
+        if (containsPropertiesTask(project.getGradle().getStartParameter())) {
+            return;
+        }
+
         Map<String, Object> args = new HashMap<>();
         args.put("plugin", BuildScanPlugin.class);
         project.apply(args);
@@ -32,6 +37,11 @@ public class ConventionGradleEnterpriseGradlePlugin implements Plugin<Project> {
         BuildScanExtension buildScan = project.getExtensions().getByType(BuildScanExtension.class);
         buildScan.setServer("https://enterprise-samples.gradle.com");
         buildScan.publishAlways();
+    }
+
+    private boolean containsPropertiesTask(StartParameter startParameter) {
+        return startParameter.getTaskNames().contains("properties")
+                || startParameter.getTaskNames().stream().anyMatch(it -> it.endsWith(":properties"));
     }
 
     private static boolean isGradle4OrNewer() {


### PR DESCRIPTION
# Overview

This PR updates the sample convention plugins to not configure build scan publishing when the `properties` task is requested. The logic is [reused from the convention plugin used by the build tool](https://github.com/gradle/gradle-org-conventions-plugin/blob/fc264a151c479c44ec057d4baef39c6844788619/src/main/java/com/gradle/enterprise/conventions/GradleEnterpriseConventionsPlugin.java#L55).

# Testing

To test this, I ran the following script and observed the output, verifying that no build scans were published when `properties` or `:properties` were requested.

```sh
#!/bin/sh

(cd plugins/gradle-2-through-4 && ./gradlew publishToMavenLocal)
(cd plugins/gradle-5-or-newer && ./gradlew publishToMavenLocal)

export GRADLE_OPTS="-Dgradle.enterprise.url=https://ge.solutions-team.gradle.com"

# first build is a sanity check that convention plugin is working
# should publish a build scan
(cd examples/gradle_6.0.1 && ./gradlew help)
(cd examples/gradle_6.0.1 && ./gradlew properties)
(cd examples/gradle_6.0.1 && ./gradlew :properties)

(cd examples/gradle_5.1.1 && ./gradlew properties)
(cd examples/gradle_5.1.1 && ./gradlew :properties)

(cd examples/gradle_4.1 && ./gradlew properties)
(cd examples/gradle_4.1 && ./gradlew :properties)

(cd examples/gradle_2.0 && ./gradlew properties)
(cd examples/gradle_2.0 && ./gradlew :properties)
```